### PR TITLE
Use slugs in permalinks because they don't work when titles contain multibyte characters

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -22,7 +22,7 @@ Paginate = 7
 canonifyurls = true
 
 [permalinks]
-  post = "/:year/:month/:title/"
+  post = "/:year/:month/:slug/"
 
 [taxonomies]
   tag = "tags"

--- a/exampleSite/content/post/Test-Chinese.md
+++ b/exampleSite/content/post/Test-Chinese.md
@@ -1,6 +1,7 @@
 ---
 title: 中文測試
 date: 2013-10-02
+slug: test-chinese
 categories:
 - tranquilpeak
 - features

--- a/exampleSite/content/post/Test-Japanese.md
+++ b/exampleSite/content/post/Test-Japanese.md
@@ -1,6 +1,7 @@
 ---
 title: 日本語テスト
 date: 2013-01-02
+slug: test-japanese
 categories:
 - tranquilpeak
 - features


### PR DESCRIPTION
The two posts in Chinese and Japanese won't be rendered unless we use slugs (which default to filenames if not specified).