### PR TITLE
added horizontal scrolling for code blocks (overflow-x:auto;)

### DIFF
--- a/src/scss/themes/_hljs-tranquilpeak.scss
+++ b/src/scss/themes/_hljs-tranquilpeak.scss
@@ -5,6 +5,11 @@ pre > code {
     color:      map-get($highlight-colors, night-rider);
 }
 
+// allow for horizontal scrolling of code blocks
+pre > code.codeblock {
+    overflow-x: auto;
+}
+
 // Default inline code
 code {
     background-color: map-get($highlight, 'background');


### PR DESCRIPTION
Code blocks didn't allow for horizontal scrolling of content when overflowing.  

This is especially helpful on mobile devices.