### PR TITLE
Remove autofocus that cause issue on FF

### DIFF
--- a/layouts/partials/search.html
+++ b/layouts/partials/search.html
@@ -9,8 +9,7 @@
       <i class="search-icon fa fa-search"></i>
       <form id="algolia-search-form">
         <input type="text" id="algolia-search-input" name="search"
-          class="form-control input--large search-input" placeholder="{{ i18n "global.search" }}"
-          autofocus="autofocus"/>
+          class="form-control input--large search-input" placeholder="{{ i18n "global.search" }}" />
       </form>
     </div>
     <div class="modal-body">


### PR DESCRIPTION
The attribute "autofocus" cause Firefox to scroll down. Since we have already set focus on the text field when we open the search modal, we don't need "autofocus" attribute any more.

fixes #69