### PR TITLE
Fix issue #113: Fix typo for post excerpt

### DIFF
--- a/archetypes/post.md
+++ b/archetypes/post.md
@@ -12,4 +12,4 @@ keywords:
 #thumbnailImage: //example.com/image.jpg
 ---
 
-<!-- more /-->
+<!--more-->

--- a/docs/user.md
+++ b/docs/user.md
@@ -520,11 +520,11 @@ The same with : `thumbnailImagePosition` set to `left`:
 
 Use: 
 
-- `<!-- more -->` to define post excerpt and keep the post excerpt in the post content
+- `<!--more-->` to define post excerpt and keep the post excerpt in the post content
 
 ### Display table of contents
 
-As post excerpt feature enable with `<!-- more -->` comment, you can display the table of contents of a post with  `<!-- toc -->`.  Place this comment where you want to display the table of content.
+As post excerpt feature enable with `<!--more-->` comment, you can display the table of contents of a post with  `<!-- toc -->`.  Place this comment where you want to display the table of content.
   
 Here is what looks like the table of contents generated:  
 ![thumbnail-image-position-left](https://s3-ap-northeast-1.amazonaws.com/tranquilpeak-hexo-theme/docs/1.4.0/toc-400.png) 


### PR DESCRIPTION
Fix a typo in user documentation and post archetype (#113),
    where <!-- more --> does not work to mark the end of a post excerpt
Hugo requires "more" not be surrounded with space for the excerpt to be
taken into account.