### PR TITLE
Fix post navigation and switch action prev/next

### DIFF
--- a/layouts/partials/post/actions.html
+++ b/layouts/partials/post/actions.html
@@ -3,22 +3,22 @@
     <ul class="post-actions post-action-nav">
       {{ if (not (eq .Params.showPagination false)) }}
         <li class="post-action">
-          {{ with .Prev }}
+          {{ with .NextInSection }}
             <a class="post-action-btn btn btn--default tooltip--top" href="{{ .RelPermalink }}" data-tooltip="{{ .Title }}">
           {{ else }}
             <a class="post-action-btn btn btn--disabled">
           {{ end }}
             <i class="fa fa-angle-left"></i>
-            <span class="hide-xs hide-sm text-small icon-ml">{{ i18n "pagination.previous" }}</span>
+            <span class="hide-xs hide-sm text-small icon-ml">{{ i18n "pagination.next" }}</span>
           </a>
         </li>
         <li class="post-action">
-          {{ with .Next }}
+          {{ with .PrevInSection }}
             <a class="post-action-btn btn btn--default tooltip--top" href="{{ .RelPermalink }}" data-tooltip="{{ .Title }}">
           {{ else }}
             <a class="post-action-btn btn btn--disabled">
           {{ end }}
-            <span class="hide-xs hide-sm text-small icon-mr">{{ i18n "pagination.next" }}</span>
+            <span class="hide-xs hide-sm text-small icon-mr">{{ i18n "pagination.previous" }}</span>
             <i class="fa fa-angle-right"></i>
           </a>
         </li>


### PR DESCRIPTION
- Since Hugo 0.18 everything is now a `Page` so navigation is still buggy because it can point to `taxonomy` or `section` where we only want to paginate `RegularPage` (fixes #119)
- Change _Next_ button that previously go to older post and _Previous_ button that previously got to newer post. @yanila-moreno highlighted a good point that _Next_ should go to newer and _Previous_ should go to older, which I think is more consistant/natural (fixes #118)