### PR TITLE
Capability to fill other attr than href/src

### DIFF
--- a/docs/user.md
+++ b/docs/user.md
@@ -359,8 +359,8 @@ E.g to display a shortcut to open algolia search window :
 | favicon | Your favicon path (Default: `/favicon.png`) |
 | imageGallery | Display an image gallery at the end of a post which have `photos` variables. (false: disabled, true: enabled) |
 | hierarchicalCategories | Define categories will create hierarchy between parents: `categories = ["foo", "bar"]` will consider "bar" a sub-category of "foo". If false it will flat categories. |
-| customCSS | Define files with css that override or extend the theme css; they are expected in `static` folder: `customCSS` = ["css/mystyles.css"]. |
-| customJS | Define files with js that override or extend the theme js; they are expected in `static` folder: `customJS` = ["js/myscripts.js"]. |
+| customCSS (_DEPRECATED see [Add custom JS or CSS using configuration](#add-custom-js-or-css-using-configuration)_) | Define files with css that override or extend the theme css: `customCSS` = ["css/mystyles.css"]. |
+| customJS (_DEPRECATED see [Add custom JS or CSS using configuration](#add-custom-js-or-css-using-configuration)_) | Define files with js that override or extend the theme js: `customJS` = ["js/myscripts.js"]. |
 
 E.g :  
 A category page look like this with `hierarchicalCategories = true` :  
@@ -368,6 +368,37 @@ A category page look like this with `hierarchicalCategories = true` :
 
 The same page with `hierarchicalCategories = false`:  
 ![hierarchicalCategories false](img/without_hierarchical_categories.png)  
+
+##### Add custom JS or CSS using configuration
+
+If you need to add some additionnal javascript or css files to your blog without forking or overriding theme itself you could use following configuration:
+
+```toml
+[params]
+  [[params.customJS]]
+    src = "https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.8.0/languages/go.min.js"
+    integrity = "sha256-LVuWfOU0rWFMCJNl1xb3K2HSWfxtK4IPbqEerP1P83M="
+    crossorigin = "anonymous"
+    async = true
+    defer = true
+
+  [[params.customJS]]
+    src = "https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.8.0/languages/dockerfile.min.js"
+    integrity = "sha256-putofyQv7OB569xAldpyBnHJ0Uc+7VGp5Us05IgDGss="
+    crossorigin = "anonymous"
+    async = true
+    defer = true
+
+  [[params.customJS]]
+    src = "js/myscript.js"
+
+  [[params.customCSS]]
+    href = "css/mystyle.css"
+```
+
+**ATTENTION** there is no limitation on key structures and each keys will be converted as tag attributes.
+
+Futhermore, even if previous syntax is still supported (`customJS = ["js/myscripts.js"]`), you can't mix both new and old syntax.
 
 #### Integrated services
 
@@ -395,7 +426,7 @@ googleAnalytics =
 | fbAdminIds | Your Facebook user ids used to connect your blog with your facebook user accounts (Facebook Insights). Use array syntax. E.g : `[9830047, 1003342]`. Visit [Facebook docs](https://developers.facebook.com/docs/platforminsights/domains) for more information. |
 | fbAppId | Your Facebook app id used to connect your blog with your facebook app account (Facebook Insights). E.g : `9841307`. Visit [Facebook docs](https://developers.facebook.com/docs/platforminsights/domains) for more information. |
 
-### Enable pages ###
+### Enable pages
 
 Tranquilpeak provides you 2 pages to display all posts title and date by tags, by categories, by date and an about page. To enable one of this pages simply add following [taxonomies](https://gohugo.io/taxonomies/overview/):
 
@@ -425,15 +456,15 @@ Follow these steps, to add new filter :
 7. Select **Custom filter**, **Filter Field** : `Hostname`, **Filter Pattern** :  `(.*?localhost.*?)`
 8. Click on **Save** button
 
-## Quick & easy modifications ##
+## Quick & easy modifications
 
-### Prerequisites ###
+### Prerequisites
 
 Since you are going to edit the theme, you have to install all the necessary to build it after changes : [Installation](https://github.com/LouisBarranqueiro/hexo-theme-tranquilpeak/blob/master/docs/developer.md#installation)
 
 **Run command in theme folder : `hexo-blog/themes/tranquilpeak`**
 
-### Change global style ###
+### Change global style
 
 If you want to change font families, font size, sidebar color, things like that, take a look at `source/scss/utils/_variables.scss` file. This file contains global variables used in this theme. **Build the theme after changes to see changes.**
 

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -92,7 +92,11 @@
     <link rel="stylesheet" href="/css/style-h63bw1xth8vvjaqwlbjvebagy7w4erwpbhxigjixv5z0adzrhcquyjicocub.min.css" />
     <!--STYLES END-->
     {{ range .Site.Params.customCSS }}
-      <link rel="stylesheet" href="{{ . | absURL }}">
+      {{ if isset . "href" }}
+        <link{{ range $key, $value := . }} {{ if eq $key "href" }}{{ (printf "%s=\"%s\"" $key ($value | absURL)) | safeHTMLAttr }}{{ else }}{{ (printf "%s=\"%s\"" $key (string $value)) | safeHTMLAttr }}{{ end }}{{ end }}></script>
+      {{ else }}
+        <link rel="stylesheet" href="{{ . | absURL }}">
+      {{ end }}
     {{ end }}
 
     {{ if .Params.ga.async }}

--- a/layouts/partials/script.html
+++ b/layouts/partials/script.html
@@ -8,7 +8,11 @@
 <script src="/js/script-wl33z0n6ocaypepiqrazthtivfrliqijej4rq8ek8gvrv1awftmgjuv8k4zc.min.js"></script>
 <!--SCRIPTS END-->
 {{ range .Site.Params.customJS }}
-   <script src="{{ . | absURL }}"></script>
+  {{ if isset . "src" }}
+    <script{{ range $key, $value := . }} {{ if eq $key "src" }}{{ (printf "%s=\"%s\"" $key ($value | absURL)) | safeHTMLAttr }}{{ else }}{{ (printf "%s=\"%s\"" $key (string $value)) | safeHTMLAttr }}{{ end }}{{ end }}></script>
+  {{ else }}
+    <script src="{{ . | absURL }}"></script>
+  {{ end }}
 {{ end }}
 <script>
 $(document).ready(function() {


### PR DESCRIPTION
Until now `customJs` and `customCSS` only create a `script` or `link` tags with `src` or `href`.

But there is no way to add/customize more attributes like `integrity`, `rel`, `type`, etc...

With new `customJS` and `customCSS` syntaxe is now possible, like following

```toml
[[params.customJS]]
  src = "https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.8.0/languages/go.min.js"
  integrity = "sha256-LVuWfOU0rWFMCJNl1xb3K2HSWfxtK4IPbqEerP1P83M="
  crossorigin = "anonymous"
  async = true
  defer = true
```

**ATTENTION** every keys of the map will be converted to tag attribute even if attribute is not part of _HTML_ spec.

Futhermore, in order to do not break existing configuration it still possible to use previous syntax:

```toml
customJS = ["https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.8.0/languages/go.min.js"]
```

**but you can't mix both syntax**, if you want to use new syntax you must first convert previous entries.