### PR TITLE
Fix wrong base URL in post page title for multilingual site

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,7 +1,7 @@
 <header id="header" data-behavior="{{ .Scratch.Get "sidebarBehavior" }}">
   <i id="btn-open-sidebar" class="fa fa-lg fa-bars"></i>
   <div class="header-title">
-    <a class="header-title-link" href="{{ "/" | relURL }}">{{ .Site.Title }}</a>
+    <a class="header-title-link" href="{{ "/" | relLangURL }}">{{ .Site.Title }}</a>
   </div>
   {{ with .Site.Params.header.rightLink }}
     {{ if and (in .url ":") (not (in .url (printf "%s" $.Site.BaseURL))) }}


### PR DESCRIPTION
The href of the title in the post pages was just "/". I changed it in order to correctly work for multilingual sites.