### PR TITLE
Add MathJax support to **tranquilpeak** theme

### DIFF
--- a/layouts/partials/script.html
+++ b/layouts/partials/script.html
@@ -64,3 +64,8 @@ $(document).ready(function() {
     </script>
   {{ end }}
 {{ end }}
+
+<script src="//yihui.name/js/math-code.js"></script>
+<script async
+src="//cdn.bootcss.com/mathjax/2.7.1/MathJax.js?config=TeX-MML-AM_CHTML">
+</script>


### PR DESCRIPTION
Snippet copied from Yihui Xie’s blogdown book. [See point 2.5.2](https://bookdown.org/yihui/blogdown/templates.html).
I added the following code at the bottom of my **`/themes/hugo-tranquilpeak-theme/layouts/partials/script.html`** file, and LaTeX code now works for me.