### PR TITLE
Swappable pagination buttons by configulation

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -172,6 +172,10 @@ canonifyurls = true
   # they have to be referred from static root. Example
   # customJS = ["js/foo.js"]
 
+  # Display `Prev` on left side of the pagination, and `Next` on right side one.
+  # If you set this value to `true`, these positions swap.
+  # swapPagenator = false
+
   # Sharing options
   # Comment and uncomment to enable or disable sharing options
   # If you wanna add a sharing option, read user documentation :

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -172,9 +172,9 @@ canonifyurls = true
   # they have to be referred from static root. Example
   # customJS = ["js/foo.js"]
 
-  # Display `Prev` on left side of the pagination, and `Next` on right side one.
+  # Display `Next` on left side of the pagination, and `Prev` on right side one.
   # If you set this value to `true`, these positions swap.
-  # swapPagenator = false
+  # swapPagenator = true
 
   # Sharing options
   # Comment and uncomment to enable or disable sharing options

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -174,7 +174,7 @@ canonifyurls = true
 
   # Display `Next` on left side of the pagination, and `Prev` on right side one.
   # If you set this value to `true`, these positions swap.
-  # swapPagenator = true
+  # swapPaginator = true
 
   # Sharing options
   # Comment and uncomment to enable or disable sharing options

--- a/layouts/partials/pagination.html
+++ b/layouts/partials/pagination.html
@@ -1,7 +1,7 @@
 {{ if or (.Paginator.HasPrev) (.Paginator.HasNext) }}
   <div class="pagination-bar">
     <ul class="pagination">
-      {{ if .Site.Params.swapPagenator }}
+      {{ if .Site.Params.swapPaginator }}
         {{ if .Paginator.HasPrev }}
           <li class="pagination-prev">
             <a class="btn btn--default btn--small" href="{{ .Paginator.Prev.URL }}">

--- a/layouts/partials/pagination.html
+++ b/layouts/partials/pagination.html
@@ -1,21 +1,40 @@
 {{ if or (.Paginator.HasPrev) (.Paginator.HasNext) }}
   <div class="pagination-bar">
     <ul class="pagination">
-      {{ if .Paginator.HasPrev }}
-        <li class="pagination-prev">
-          <a class="btn btn--default btn--small" href="{{ .Paginator.Prev.URL }}">
-            <i class="fa fa-angle-left text-base icon-mr"></i>
-            <span>{{ i18n "pagination.newer_posts" }}</span>
-          </a>
-        </li>
-      {{ end }}
-      {{ if .Paginator.HasNext }}
-        <li class="pagination-next">
-          <a class="btn btn--default btn--small" href="{{ .Paginator.Next.URL }}">
-            <span>{{ i18n "pagination.older_posts" }}</span>
-            <i class="fa fa-angle-right text-base icon-ml"></i>
-          </a>
-        </li>
+      {{ if .Site.Params.swapPagenator }}
+        {{ if .Paginator.HasNext }}
+          <li class="pagination-next">
+            <a class="btn btn--default btn--small" href="{{ .Paginator.Next.URL }}">
+              <i class="fa fa-angle-left text-base icon-mr"></i>
+              <span>{{ i18n "pagination.newer_posts" }}</span>
+            </a>
+          </li>
+        {{ end }}
+        {{ if .Paginator.HasPrev }}
+          <li class="pagination-prev">
+            <a class="btn btn--default btn--small" href="{{ .Paginator.Prev.URL }}">
+              <span>{{ i18n "pagination.older_posts" }}</span>
+              <i class="fa fa-angle-right text-base icon-ml"></i>
+            </a>
+          </li>
+        {{ end }}
+      {{ else }}
+        {{ if .Paginator.HasPrev }}
+          <li class="pagination-prev">
+            <a class="btn btn--default btn--small" href="{{ .Paginator.Prev.URL }}">
+              <i class="fa fa-angle-left text-base icon-mr"></i>
+              <span>{{ i18n "pagination.older_posts" }}</span>
+            </a>
+          </li>
+        {{ end }}
+        {{ if .Paginator.HasNext }}
+          <li class="pagination-next">
+            <a class="btn btn--default btn--small" href="{{ .Paginator.Next.URL }}">
+              <span>{{ i18n "pagination.newer_posts" }}</span>
+              <i class="fa fa-angle-right text-base icon-ml"></i>
+            </a>
+          </li>
+        {{ end }}
       {{ end }}
       <li class="pagination-number">{{ i18n "pagination.page" . }} {{ i18n "pagination.of" . }}</li>
     </ul>

--- a/layouts/partials/pagination.html
+++ b/layouts/partials/pagination.html
@@ -2,35 +2,35 @@
   <div class="pagination-bar">
     <ul class="pagination">
       {{ if .Site.Params.swapPagenator }}
-        {{ if .Paginator.HasNext }}
-          <li class="pagination-next">
-            <a class="btn btn--default btn--small" href="{{ .Paginator.Next.URL }}">
-              <i class="fa fa-angle-left text-base icon-mr"></i>
-              <span>{{ i18n "pagination.newer_posts" }}</span>
-            </a>
-          </li>
-        {{ end }}
         {{ if .Paginator.HasPrev }}
           <li class="pagination-prev">
             <a class="btn btn--default btn--small" href="{{ .Paginator.Prev.URL }}">
+              <i class="fa fa-angle-left text-base icon-mr"></i>
               <span>{{ i18n "pagination.older_posts" }}</span>
+            </a>
+          </li>
+        {{ end }}
+        {{ if .Paginator.HasNext }}
+          <li class="pagination-next">
+            <a class="btn btn--default btn--small" href="{{ .Paginator.Next.URL }}">
+              <span>{{ i18n "pagination.newer_posts" }}</span>
               <i class="fa fa-angle-right text-base icon-ml"></i>
             </a>
           </li>
         {{ end }}
       {{ else }}
-        {{ if .Paginator.HasPrev }}
-          <li class="pagination-prev">
-            <a class="btn btn--default btn--small" href="{{ .Paginator.Prev.URL }}">
-              <i class="fa fa-angle-left text-base icon-mr"></i>
-              <span>{{ i18n "pagination.older_posts" }}</span>
-            </a>
-          </li>
-        {{ end }}
         {{ if .Paginator.HasNext }}
           <li class="pagination-next">
             <a class="btn btn--default btn--small" href="{{ .Paginator.Next.URL }}">
+              <i class="fa fa-angle-left text-base icon-mr"></i>
               <span>{{ i18n "pagination.newer_posts" }}</span>
+            </a>
+          </li>
+        {{ end }}
+        {{ if .Paginator.HasPrev }}
+          <li class="pagination-prev">
+            <a class="btn btn--default btn--small" href="{{ .Paginator.Prev.URL }}">
+              <span>{{ i18n "pagination.older_posts" }}</span>
               <i class="fa fa-angle-right text-base icon-ml"></i>
             </a>
           </li>

--- a/layouts/partials/post/actions.html
+++ b/layouts/partials/post/actions.html
@@ -9,9 +9,9 @@
               {{ else }}
                 <a class="post-action-btn btn btn--disabled">
               {{ end }}
-                <i class="fa fa-angle-left"></i>
-                <span class="hide-xs hide-sm text-small icon-ml">{{ i18n "pagination.previous" }}</span>
-              </a>
+                  <i class="fa fa-angle-left"></i>
+                  <span class="hide-xs hide-sm text-small icon-ml">{{ i18n "pagination.previous" }}</span>
+                </a>
             </li>
             <li class="post-action">
               {{ with .NextInSection }}
@@ -19,9 +19,9 @@
               {{ else }}
                 <a class="post-action-btn btn btn--disabled">
               {{ end }}
-                <span class="hide-xs hide-sm text-small icon-mr">{{ i18n "pagination.next" }}</span>
-                <i class="fa fa-angle-right"></i>
-              </a>
+                  <span class="hide-xs hide-sm text-small icon-mr">{{ i18n "pagination.next" }}</span>
+                  <i class="fa fa-angle-right"></i>
+                </a>
             </li>
           {{ else }}
             <li class="post-action">
@@ -30,9 +30,9 @@
               {{ else }}
                 <a class="post-action-btn btn btn--disabled">
               {{ end }}
-                <i class="fa fa-angle-left"></i>
-                <span class="hide-xs hide-sm text-small icon-ml">{{ i18n "pagination.next" }}</span>
-              </a>
+                  <i class="fa fa-angle-left"></i>
+                  <span class="hide-xs hide-sm text-small icon-ml">{{ i18n "pagination.next" }}</span>
+                </a>
             </li>
             <li class="post-action">
               {{ with .PrevInSection }}
@@ -40,9 +40,9 @@
               {{ else }}
                 <a class="post-action-btn btn btn--disabled">
               {{ end }}
-              <span class="hide-xs hide-sm text-small icon-mr">{{ i18n "pagination.previous" }}</span>
-              <i class="fa fa-angle-right"></i>
-              </a>
+                  <span class="hide-xs hide-sm text-small icon-mr">{{ i18n "pagination.previous" }}</span>
+                  <i class="fa fa-angle-right"></i>
+                </a>
             </li>
           {{ end }}
         </ul>

--- a/layouts/partials/post/actions.html
+++ b/layouts/partials/post/actions.html
@@ -4,27 +4,6 @@
         <ul class="post-actions post-action-nav">
           {{ if .Site.Params.swapPagenator }}
             <li class="post-action">
-              {{ with .NextInSection }}
-                <a class="post-action-btn btn btn--default tooltip--top" href="{{ .RelPermalink }}" data-tooltip="{{ .Title }}">
-              {{ else }}
-                <a class="post-action-btn btn btn--disabled">
-              {{ end }}
-                <i class="fa fa-angle-left"></i>
-                <span class="hide-xs hide-sm text-small icon-ml">{{ i18n "pagination.next" }}</span>
-              </a>
-            </li>
-            <li class="post-action">
-              {{ with .PrevInSection }}
-                <a class="post-action-btn btn btn--default tooltip--top" href="{{ .RelPermalink }}" data-tooltip="{{ .Title }}">
-              {{ else }}
-                <a class="post-action-btn btn btn--disabled">
-              {{ end }}
-              <span class="hide-xs hide-sm text-small icon-mr">{{ i18n "pagination.previous" }}</span>
-              <i class="fa fa-angle-right"></i>
-              </a>
-            </li>
-          {{ else }}
-            <li class="post-action">
               {{ with .PrevInSection }}
                 <a class="post-action-btn btn btn--default tooltip--top" href="{{ .RelPermalink }}" data-tooltip="{{ .Title }}">
               {{ else }}
@@ -42,6 +21,27 @@
               {{ end }}
                 <span class="hide-xs hide-sm text-small icon-mr">{{ i18n "pagination.next" }}</span>
                 <i class="fa fa-angle-right"></i>
+              </a>
+            </li>
+          {{ else }}
+            <li class="post-action">
+              {{ with .NextInSection }}
+                <a class="post-action-btn btn btn--default tooltip--top" href="{{ .RelPermalink }}" data-tooltip="{{ .Title }}">
+              {{ else }}
+                <a class="post-action-btn btn btn--disabled">
+              {{ end }}
+                <i class="fa fa-angle-left"></i>
+                <span class="hide-xs hide-sm text-small icon-ml">{{ i18n "pagination.next" }}</span>
+              </a>
+            </li>
+            <li class="post-action">
+              {{ with .PrevInSection }}
+                <a class="post-action-btn btn btn--default tooltip--top" href="{{ .RelPermalink }}" data-tooltip="{{ .Title }}">
+              {{ else }}
+                <a class="post-action-btn btn btn--disabled">
+              {{ end }}
+              <span class="hide-xs hide-sm text-small icon-mr">{{ i18n "pagination.previous" }}</span>
+              <i class="fa fa-angle-right"></i>
               </a>
             </li>
           {{ end }}

--- a/layouts/partials/post/actions.html
+++ b/layouts/partials/post/actions.html
@@ -2,7 +2,7 @@
   <div class="post-actions-wrap">
       <nav {{ if eq .Params.showPagination false }}style="visibility: hidden"{{ end }}>
         <ul class="post-actions post-action-nav">
-          {{ if .Site.Params.swapPagenator }}
+          {{ if .Site.Params.swapPaginator }}
             <li class="post-action">
               {{ with .PrevInSection }}
                 <a class="post-action-btn btn btn--default tooltip--top" href="{{ .RelPermalink }}" data-tooltip="{{ .Title }}">

--- a/layouts/partials/post/actions.html
+++ b/layouts/partials/post/actions.html
@@ -2,6 +2,7 @@
   <div class="post-actions-wrap">
       <nav {{ if eq .Params.showPagination false }}style="visibility: hidden"{{ end }}>
         <ul class="post-actions post-action-nav">
+          {{ if .Site.Params.swapPagenator }}
             <li class="post-action">
               {{ with .NextInSection }}
                 <a class="post-action-btn btn btn--default tooltip--top" href="{{ .RelPermalink }}" data-tooltip="{{ .Title }}">
@@ -18,10 +19,32 @@
               {{ else }}
                 <a class="post-action-btn btn btn--disabled">
               {{ end }}
-                <span class="hide-xs hide-sm text-small icon-mr">{{ i18n "pagination.previous" }}</span>
+              <span class="hide-xs hide-sm text-small icon-mr">{{ i18n "pagination.previous" }}</span>
+              <i class="fa fa-angle-right"></i>
+              </a>
+            </li>
+          {{ else }}
+            <li class="post-action">
+              {{ with .PrevInSection }}
+                <a class="post-action-btn btn btn--default tooltip--top" href="{{ .RelPermalink }}" data-tooltip="{{ .Title }}">
+              {{ else }}
+                <a class="post-action-btn btn btn--disabled">
+              {{ end }}
+                <i class="fa fa-angle-left"></i>
+                <span class="hide-xs hide-sm text-small icon-ml">{{ i18n "pagination.previous" }}</span>
+              </a>
+            </li>
+            <li class="post-action">
+              {{ with .NextInSection }}
+                <a class="post-action-btn btn btn--default tooltip--top" href="{{ .RelPermalink }}" data-tooltip="{{ .Title }}">
+              {{ else }}
+                <a class="post-action-btn btn btn--disabled">
+              {{ end }}
+                <span class="hide-xs hide-sm text-small icon-mr">{{ i18n "pagination.next" }}</span>
                 <i class="fa fa-angle-right"></i>
               </a>
             </li>
+          {{ end }}
         </ul>
       </nav>
     <ul class="post-actions post-action-share" >


### PR DESCRIPTION
~~adjust to original hexo tranquilpeak theme~~
~~ref: [hexo's demo page](http://louisbarranqueiro.github.io/hexo-theme-tranquilpeak/2015/05/28/Elements-showcase/)~~

add `swapPaginator` option to configulation.
default pagenator looks like `< NEXT | PREV >`
![image](https://user-images.githubusercontent.com/1488898/30546749-6d58a988-9cc8-11e7-89db-0993475230e9.png)

If set this value to `true`, it looks like `< PREV | NEXT >`
(it seems general UI design, hexo's one, google, amazon etc,etc...)
![image](https://user-images.githubusercontent.com/1488898/30546729-5a96848c-9cc8-11e7-99b5-d43359ec1a3a.png)

updated: 2017-09-23