### PR TITLE
Add custom dateFormat docs and remove month suffix

### DIFF
--- a/docs/user.md
+++ b/docs/user.md
@@ -1,4 +1,4 @@
-# User documentation
+﻿# User documentation
 
 A gorgeous responsive theme for Hugo blog framework
 
@@ -171,7 +171,7 @@ You can customize it by setting
 
 Will produce: "2 January 2006"
 
-ATTENTION: date format should respect `go` `Time` package syntax, please refer to https://golang.org/pkg/time/
+**ATTENTION**: date format should respect `go` `Time` package syntax, please refer to https://golang.org/pkg/time/
 
 **Moreover, if you are using fully named month (short named month like "jan", "feb", etc is not supported), month will be translated.**
 
@@ -182,6 +182,25 @@ defaultContentLanguage = "fr-fr"
 ```
 
 "21 July 2006" will be output "21 Juillet 2006".
+
+**If you want to change format for other languages, you can declare them into hugo' language tag as:**
+
+```toml
+[params]
+  # Default Date Format
+  dateFormat = "2 January 2006"
+  # The output will be: `2 January 2006`
+
+# Custom Date Format for Vietnamese
+[languages.vi]
+dateFormat = "ngày 2 January năm 2006"
+# The output will be: `ngày 2 tháng 1 năm 2006`
+
+# Custom Date Format for Japanese
+[languages.ja]
+dateFormat = "2006年January2日"
+# The output will be: `2006年1月2日`
+```
 
 ### Define global keywords
 

--- a/docs/user.md
+++ b/docs/user.md
@@ -1,6 +1,6 @@
 # User documentation
 
-A gorgeous responsive theme for Hugo blog framework 
+A gorgeous responsive theme for Hugo blog framework
 
 [![Tranquilpeak](../showcase.png)](https://tranquilpeak.kakawait.com)
 
@@ -70,7 +70,7 @@ If you want to report a bug or ask a question, [create an issue](https://github.
 - Support Open Graph protocol
 - Easily customizable (fonts, colors, layout elements, code coloration, etc..)
 - Support internationalization (i18)
-  
+
 **Posts features:**  
 
 - Thumbnail image
@@ -82,7 +82,7 @@ If you want to report a bug or ask a question, [create an issue](https://github.
 - Image gallery
 - Tags for images (FancyBox), wide images, tabbed code blocks, highlighted text, alerts
 - Table of contents  
-  
+
 **Integrated services:**  
 
 - Disqus
@@ -175,13 +175,13 @@ ATTENTION: date format should respect `go` `Time` package syntax, please refer t
 
 **Moreover, if you are using fully named month (short named month like "jan", "feb", etc is not supported), month will be translated.**
 
-Example: 
+Example:
 
 ```toml
 defaultContentLanguage = "fr-fr"
 ```
 
-"21 July 2006" will be output "21 Juillet 2006". 
+"21 July 2006" will be output "21 Juillet 2006".
 
 ### Define global keywords
 
@@ -197,7 +197,7 @@ You can define keywords for search engines. These keywords will be added on all 
 Backup your configuration:
 
 ```bash
-cp config.{toml,yml,json} config.{toml,yml,json}.backup 
+cp config.{toml,yml,json} config.{toml,yml,json}.backup
 ```
 
 Copy example configuration
@@ -321,7 +321,7 @@ E.g to display a shortcut to open algolia search window :
   # Your google plus profile id. E.g : +ThibaudLepretre or 114625208755123718311
   googlePlus = "+ThibaudLepretre"
 ```
-  
+
 | Variable        | Description                                                                          |
 |-----------------|--------------------------------------------------------------------------------------|
 | name            | Your name                                                                            |
@@ -405,7 +405,7 @@ Futhermore, even if previous syntax is still supported (`customJS = ["js/myscrip
 
 ```toml
 disqusShortname =
-googleAnalytics = 
+googleAnalytics =
 ```
 
 ```toml
@@ -415,8 +415,8 @@ googleAnalytics =
 
 ```toml
 [params]
-  fbAdminIds = 
-  fbAppId = 
+  fbAdminIds =
+  fbAppId =
 ```
 
 | Variable | Description |
@@ -482,7 +482,7 @@ Tranquilpeak provides you 2 pages to display all posts title and date by tags, b
 While you are writing articles, you need to check the result a lot of times before deploying your site.
 If you have enable Google analytics service, Google will include all requests done, even when hostname is localhost and this can greatly skew the results.
 To overcome this, you have to add a filter on Google Analytics website.
-   
+
 Follow these steps, to add new filter :
 
 1. Sign in to your Google Analytics account
@@ -507,15 +507,15 @@ If you want to change font families, font size, sidebar color, things like that,
 
 ### Change code coloration (Highlight.js theme)
 
-Tranquilpeak integrate its own highlight.js theme inspired by GitHub. 
-Of course, you can replace it with an other theme found on highlight.js repository. Since Hexo use different CSS class names, all theme are not ready out of the box, but it is very easy to make them compatible. 
+Tranquilpeak integrate its own highlight.js theme inspired by GitHub.
+Of course, you can replace it with an other theme found on highlight.js repository. Since Hexo use different CSS class names, all theme are not ready out of the box, but it is very easy to make them compatible.
 
 Follow these steps :
 
 1. Get your theme here : [Highlight.js theme](https://github.com/isagalaev/highlight.js/tree/master/src/styles) or create yours
 2. Follow guidelines in `source/scss/themes/hljs-custom.scss` file
 3. Build the theme with `npm run prod` or `grunt buildProd`. Learn more about Grunt tasks : [Grunt tasks](https://github.com/LouisBarranqueiro/hexo-theme-tranquilpeak/blob/master/docs/developer.md#grunt-tasks)
- 
+
 ## Writing posts
 
 To write articles, you have to use Markdown language. [Here](https://guides.github.com/features/mastering-markdown/#examples) you can find the main basics of Markdown syntax.   
@@ -526,7 +526,7 @@ Please note, there are many different versions of Markdown and some of them are 
 ### Front-matter settings
 
 Tranquilpeak introduces new variables to give you a lot of possibilities.  
-  
+
 Example :  
 ``` markdown
 disqusIdentifier: fdsF34ff34
@@ -553,6 +553,7 @@ showTags: true
 showPagination: true
 showSocial: true
 showDate: true
+canonical: false
 ```
 
 |Variable|Description|
@@ -576,30 +577,31 @@ showDate: true
 |showSocial|`true`: show social button such as share on Twitter, Facebook...|
 |showMeta|`true`: Show post meta (date, categories).|
 |showActions|`true`: Show post actions (navigation, share links).|
+|canonical|`true`: Add `rel="canonical"` to avoid duplicate content when `true` (default)|
 
-Example: 
+Example:
 A post on index page will look like this with :`thumbnailImagePosition` set to `bottom`:  
 ![thumbnail-image-position-bottom](https://s3-ap-northeast-1.amazonaws.com/tranquilpeak-hexo-theme/docs/1.4.0/TIP-bottom-400.jpg)  
-  
+
 The same with : `thumbnailImagePosition` set to `right`:  
 ![thumbnail-image-position-right](https://s3-ap-northeast-1.amazonaws.com/tranquilpeak-hexo-theme/docs/1.4.0/TIP-right-400.png)  
-  
+
 The same with : `thumbnailImagePosition` set to `left`:  
 ![thumbnail-image-position-left](https://s3-ap-northeast-1.amazonaws.com/tranquilpeak-hexo-theme/docs/1.4.0/TIP-left-400.png)  
 
 ### Define post excerpt
 
-Use: 
+Use:
 
 - `<!--more-->` to define post excerpt and keep the post excerpt in the post content
 
 ### Display table of contents
 
 As post excerpt feature enable with `<!--more-->` comment, you can display the table of contents of a post with  `<!-- toc -->`.  Place this comment where you want to display the table of content.
-  
+
 Here is what looks like the table of contents generated:  
-![thumbnail-image-position-left](https://s3-ap-northeast-1.amazonaws.com/tranquilpeak-hexo-theme/docs/1.4.0/toc-400.png) 
-  
+![thumbnail-image-position-left](https://s3-ap-northeast-1.amazonaws.com/tranquilpeak-hexo-theme/docs/1.4.0/toc-400.png)
+
 ### Tags
 
 Tranquilpeak introduce new tags to display alert messages, images in full width and create beautiful galleries.
@@ -617,7 +619,7 @@ content
 {{< /alert >}}
 ```
 
-E.g: 
+E.g:
 ```
 {{< alert danger no-icon >}}
 Here is a danger alert without icon
@@ -639,7 +641,7 @@ Syntax:
 {{< hl-text [classes] >}}
 content
 {{< /hl-text >}}
-``` 
+```
 
 E.g:  
 ```
@@ -649,10 +651,10 @@ your highlighted text
 ```
 
 |Argument|Description|
-|---|---| 
+|---|---|
 |Classes|<strong>classes</strong> : <ul><li>red</li><li>green</li><li>blue</li><li>purple</li><li>orange</li><li>yellow</li><li>cyan</li><li>primary</li><li>success</li><li>warning</li><li>danger</li></ul>|
-        
-**It's important to put the paragraph that contains highlight text tag inside** `<p>...</p>` 
+
+**It's important to put the paragraph that contains highlight text tag inside** `<p>...</p>`
 **otherwise the following content may not be rendered.**
 
 #### Image
@@ -670,7 +672,7 @@ E.g:
 ```
 
 |Argument|Description|
-|---|---| 
+|---|---|
 |classes (optional)|You can add css classes to stylize the image. Separate class with whitespace. Tranquilpeak integrate many css class to create nice effects :  <ul><li><strong>fancybox</strong> : Generate a fancybox image.</li><li><strong>nocaption</strong> : Caption of the image will not be displayed.</li><li><strong>left</strong> : Image will float at the left.</li><li><strong>right</strong> : Image will float at the right.</li><li><strong>center</strong> : Image will be at center.</li><li><strong>fig-20</strong> : Image will take 20% of the width of post width and automatically float at left.</li><li><strong>fig-25</strong> : Image will take 25% of the width of post width and automatically float at left.</li><li><strong>fig-33</strong> : Image will take 33% of the width of post width and automatically float at left.</li><li><strong>fig-50</strong> : Image will take 50% of the width of post width and automatically float at left.</li><li><strong>fig-75</strong> : Image will take 75% of the width of post width and automatically float at left.</li><li><strong>fig-100</strong> : Image will take 100% of the width of post width.</li><li><strong>clear</strong> : Add a div with `clear:both;` style attached after the image to retrieve the normal flow of the post.</li></ul>|
 |group (optional)| Name of a group, used to create a gallery. **Only for image with `fancybox` css class**|
 |src| Path to the original image.|
@@ -678,7 +680,7 @@ E.g:
 |thumbnail-width (optional)| Width to the thumbnail image. If the thumbnail image is empty, width will be attached to thumbnail image created from original image. E.g : `150px` or `85%`.|
 |thumbnail-height (optional)| Height to the thumbnail image. If the thumbnail image is empty, height will be attached to thumbnail image created from original image. E.g : `300px` or `20%`.|
 |title (optional)| Title of image displayed in a caption under image. `Alt` HTML attribute will use this title. E.g : `"A beautiful sunrise"`.|
- 
+
 #### Tabbed code block
 
 Tabbed code blocks are useful to group multiple code blocks related. For example, the source code of a web component (html, css and js). Or compare a source code in different languages.
@@ -708,9 +710,9 @@ E.g:
         }
     <!-- endtab -->
 {{< /tabbed-codeblock >}}
-``` 
+```
 |Argument|Description|
-|---|---| 
+|---|---|
 |Name (optional)|Name of the code block, or of the file|
 |Link (optional)|Link to a demo, or a file|
 |Lang (optional)|Programming language use for the current tab|
@@ -727,21 +729,21 @@ Syntax:
 E.g:
 ```
 {{< wide-image src="http://google.fr/images/image125.png" title="A beautiful sunrise" >}}
-``` 
+```
 
 |Argument|Description|
-|---|---| 
+|---|---|
 |src|Path to the original image.|
-|title (optional)|Title of image displayed in a caption under image. `Alt` HTML attribute will use this title. E.g : `"A beautiful sunrise"`.| 
-  
+|title (optional)|Title of image displayed in a caption under image. `Alt` HTML attribute will use this title. E.g : `"A beautiful sunrise"`.|
+
 
 ## Writing pages ##
 
 Sometimes you need to create a **page** that is **not** a **regular blog post**,
-where you want to hide the date, social sharing buttons, tags, categories 
+where you want to hide the date, social sharing buttons, tags, categories
 and pagination.
 This is the case for the blog pages _About_ or _Contact_ for instance which do
-not need to be timestamped (nor tagged or categorized) nor provide 
+not need to be timestamped (nor tagged or categorized) nor provide
 pagination and are not intended to be shared on social networks.
 
 In order to create such a page you can proceed like so:

--- a/i18n/ja.yaml
+++ b/i18n/ja.yaml
@@ -1,4 +1,4 @@
-## GLOBAL ##
+﻿## GLOBAL ##
 - id: "global.home"
   translation: "ホーム"
 
@@ -95,10 +95,10 @@
 
 ## POST ##
 - id: "post.no_title"
-  translation: "タイトルなし"
+  translation: "無題"
 
 - id: "post.categorized_in"
-  translation: "カテゴリー"
+  translation: "　"
 
 - id: "post.tagged_in"
   translation: "タグ"
@@ -123,44 +123,38 @@
 - id: "date.year.suffix"
   translation: "年"
 
-- id: "date.month.suffix"
-  translation: "月"
-
-- id: "date.day.suffix"
-  translation: "日"
-
 - id: "date.month.january"
-  translation: "1"
+  translation: "1月"
 
 - id: "date.month.february"
-  translation: "2"
+  translation: "2月"
 
 - id: "date.month.march"
-  translation: "3"
+  translation: "3月"
 
 - id: "date.month.april"
-  translation: "4"
+  translation: "4月"
 
 - id: "date.month.may"
-  translation: "5"
+  translation: "5月"
 
 - id: "date.month.june"
-  translation: "6"
+  translation: "6月"
 
 - id: "date.month.july"
-  translation: "7"
+  translation: "7月"
 
 - id: "date.month.august"
-  translation: "8"
+  translation: "8月"
 
 - id: "date.month.september"
-  translation: "9"
+  translation: "9月"
 
 - id: "date.month.october"
-  translation: "10"
+  translation: "10月"
 
 - id: "date.month.november"
-  translation: "11"
+  translation: "11月"
 
 - id: "date.month.december"
-  translation: "12"
+  translation: "12月"

--- a/i18n/vi.yaml
+++ b/i18n/vi.yaml
@@ -95,10 +95,10 @@
 
 ## POST ##
 - id: "post.no_title"
-  translation: "Không có tiêu đề"
+  translation: "Vô đề"
 
 - id: "post.categorized_in"
-  translation: "trong"
+  translation: "mục"
 
 - id: "post.tagged_in"
   translation: "THẺ ĐÁNH DẤU"

--- a/layouts/partials/archive-post.html
+++ b/layouts/partials/archive-post.html
@@ -6,7 +6,7 @@
       <h4 class="archive-title" style="text-decoration: none;">{{ $year }}{{ if i18n "date.year.suffix" }}{{ i18n "date.year.suffix" }}{{ end }}</h4>
       {{ range .Pages.GroupByDate "01-January" }}
         <ul class="archive-posts archive-month" data-date="{{ $year }}{{ range first 1 (split .Key "-") }}{{ . }}{{ end }}">
-          <h5 class="archive-title" style="text-decoration: none;">{{ range last 1 (split .Key "-") }}{{ i18n (lower (printf "date.month.%s" .)) }}{{ if i18n "date.month.suffix" }}{{ i18n "date.month.suffix" }}{{ end }}{{ end }}</h5>
+          <h5 class="archive-title" style="text-decoration: none;">{{ range last 1 (split .Key "-") }}{{ i18n (lower (printf "date.month.%s" .)) }}{{ end }}</h5>
           {{ range .Pages }}
             <li class="archive-post archive-day" data-date="{{ dateFormat "20060102" .Date }}">
               <a class="archive-post-title" href="{{ .Permalink }}">{{ .Title }}</a>

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -27,6 +27,7 @@
     {{ partial "head_start.html" . }}
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="generator" content="Hugo {{ .Hugo.Version }} with theme Tranquilpeak 0.4.2-SNAPSHOT">
     <title>{{ with .Title }}{{ . }}{{ else }}{{ .Site.Title }}{{ end }}</title>
     <meta name="author" content="{{ .Site.Author.name }}">
@@ -39,13 +40,15 @@
 
     <!-- open graph data -->
     <meta name="description" content="{{ if .Description }}{{ .Description }}{{ else if .IsPage }}{{ .Summary }}{{ else }}{{ .Site.Params.description }}{{ end }}">
-    <meta property="og:description" content="{{ if .Description }}{{ .Description }}{{ else if .IsPage }}{{ .Summary }}{{ else }}{{ .Site.Params.description }}{{ end }}">
     <meta property="og:type" content="blog">
     <meta property="og:title" content="{{ with .Title }}{{ . }}{{ else }}{{ .Site.Title }}{{ end }}">
-    <meta property="og:url" content="{{ .URL }}">
+    <meta property="og:url" content="{{ .Permalink }}">
+    <meta property="og:description" content="{{ if .Description }}{{ .Description }}{{ else if .IsPage }}{{ .Summary }}{{ else }}{{ .Site.Params.description }}{{ end }}">
     <meta property="og:site_name" content="{{ .Site.Title }}">
+    <meta property="og:locale" content="{{ .Lang }}">
     <meta name="twitter:card" content="summary">
-    <meta name="twitter:title" content="{{ .Site.Title }}">
+    <meta name="twitter:title" content="{{ with .Title }}{{ . }}{{ else }}{{ .Site.Title }}{{ end }}">
+    <meta name="twitter:url" content="{{ .Permalink }}">
     <meta name="twitter:description" content="{{ if .Description }}{{ .Description }}{{ else if .IsPage }}{{ .Summary }}{{ else }}{{ .Site.Params.description }}{{ end }}">
     {{ with .Site.Author.twitter }}
       <meta name="twitter:creator" content="@{{ . }}">
@@ -63,23 +66,28 @@
 
     {{ if .Scratch.Get "gravatarEmail" }}
       <meta property="og:image" content="//www.gravatar.com/avatar/{{ (md5 (.Scratch.Get "gravatarEmail")) | urlize }}?s=640">
+      <meta name="twitter:image" content="//www.gravatar.com/avatar/{{ (md5 (.Scratch.Get "gravatarEmail")) | urlize }}?s=640">
     {{ else if .Site.Author.picture }}
       <meta property="og:image" content="{{ .Site.Author.picture | absURL }}">
+      <meta name="twitter:image" content="{{ .Site.Author.picture | absURL }}">
     {{ end }}
 
     {{ with .Params.thumbnailImage }}
       <meta property="og:image" content="{{ . | absURL }}">
+      <meta name="twitter:image" content="{{ . | absURL }}">
     {{ end }}
     {{ with .Params.coverImage }}
       <meta property="og:image" content="{{ . | absURL }}">
+      <meta name="twitter:image" content="{{ . | absURL }}">
     {{ end }}
     {{ with .Params.gallery }}
       {{ range . }}
         <meta property="og:image" content="{{ range first 1 (split . " ") }}{{ . | absURL }}{{ end }}">
+        <meta name="twitter:image" content="{{ range first 1 (split . " ") }}{{ . | absURL }}{{ end }}">
       {{ end }}
     {{ end }}
 
-    {{ with .Site.Author.googlePlus }}
+    {{ with .Site.Author.googleplus }}
       <link rel="publisher" href="https://plus.google.com/{{ . | urlize }}">
     {{ end }}
 

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -38,6 +38,10 @@
       <link rel="alternate" type="application/rss+xml" title="RSS" href="{{ . }}">
     {{ end }}
 
+    {{ if not (eq .Params.canonical false) }}
+      <link rel="canonical" href="{{ .Permalink }}" />
+    {{ end }}
+
     <!-- open graph data -->
     <meta name="description" content="{{ if .Description }}{{ .Description }}{{ else if .IsPage }}{{ .Summary }}{{ else }}{{ .Site.Params.description }}{{ end }}">
     <meta property="og:type" content="blog">

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -17,7 +17,7 @@
   {{ .Scratch.Set "gravatarEmail" .Site.Author.gravataremail }}
 {{ end }}
 {{ if .Scratch.Get "gravatarEmail" }}
-  {{ .Scratch.Set "authorPicture" (printf "//www.gravatar.com/avatar/%s" (urlize (md5 (.Scratch.Get "gravatarEmail")))) }}
+  {{ .Scratch.Set "authorPicture" (printf "https://www.gravatar.com/avatar/%s" (urlize (md5 (.Scratch.Get "gravatarEmail")))) }}
 {{ else if .Site.Author.picture }}
   {{ .Scratch.Set "authorPicture" (absURL .Site.Author.picture) }}
 {{ end }}
@@ -44,7 +44,7 @@
 
     <!-- open graph data -->
     <meta name="description" content="{{ if .Description }}{{ .Description }}{{ else if .IsPage }}{{ .Summary }}{{ else }}{{ .Site.Params.description }}{{ end }}">
-    <meta property="og:type" content="blog">
+    <meta property="og:type" content="website">
     <meta property="og:title" content="{{ with .Title }}{{ . }}{{ else }}{{ .Site.Title }}{{ end }}">
     <meta property="og:url" content="{{ .Permalink }}">
     <meta property="og:description" content="{{ if .Description }}{{ .Description }}{{ else if .IsPage }}{{ .Summary }}{{ else }}{{ .Site.Params.description }}{{ end }}">
@@ -69,8 +69,8 @@
     {{ end }}
 
     {{ if .Scratch.Get "gravatarEmail" }}
-      <meta property="og:image" content="//www.gravatar.com/avatar/{{ (md5 (.Scratch.Get "gravatarEmail")) | urlize }}?s=640">
-      <meta name="twitter:image" content="//www.gravatar.com/avatar/{{ (md5 (.Scratch.Get "gravatarEmail")) | urlize }}?s=640">
+      <meta property="og:image" content="https://www.gravatar.com/avatar/{{ (md5 (.Scratch.Get "gravatarEmail")) | urlize }}?s=640">
+      <meta name="twitter:image" content="https://www.gravatar.com/avatar/{{ (md5 (.Scratch.Get "gravatarEmail")) | urlize }}?s=640">
     {{ else if .Site.Author.picture }}
       <meta property="og:image" content="{{ .Site.Author.picture | absURL }}">
       <meta name="twitter:image" content="{{ .Site.Author.picture | absURL }}">


### PR DESCRIPTION
We don't need month suffix for output date because it will be translated.

And we can custom `dateFormat` for specific language by using Hugo language configuration.
I have just add these config e.x into the User Docs.