### PR TITLE
Removing unwanted posts link from archives

### DIFF
--- a/layouts/partials/search.html
+++ b/layouts/partials/search.html
@@ -15,7 +15,7 @@
     <div class="modal-body">
       <div class="no-result text-color-light text-center">{{ i18n "global.posts_found.zero" }}</div>
       <div class="results">
-        {{ $posts := (where .Site.Pages "Section" "post") }}
+        {{ $posts := (where .Site.RegularPages "Section" "post") }}
         {{ range first 10 $posts }}
           <div class="media">
             {{ if .Params.thumbnailImageUrl }}

--- a/layouts/taxonomy/archive.terms.html
+++ b/layouts/taxonomy/archive.terms.html
@@ -11,7 +11,7 @@
           <form id="filter-form" action="#">
             <input name="date" type="text" class="form-control input--xlarge" placeholder="{{ i18n "global.search_date" }}" autofocus="autofocus">
           </form>
-          {{ partial "archive-post.html" (where .Site.Pages "Type" "post") }}
+          {{ partial "archive-post.html" (where .Site.RegularPages "Type" "post") }}
         </div>
       </div>
     </div>

--- a/layouts/taxonomy/category.terms.html
+++ b/layouts/taxonomy/category.terms.html
@@ -1,6 +1,6 @@
 {{ if $.Site.Params.hierarchicalCategories }}
   {{ $.Scratch.Set "max-level" 0 }}
-  {{ range where $.Site.Pages "Type" "post" }}
+  {{ range where $.Site.RegularPages "Type" "post" }}
     {{ $page := . }}
     {{ if .Params.categories }}
       {{ $categories := (apply .Params.categories "urlize" ".") }}


### PR DESCRIPTION
Since Hugo 0.18 (see note http://bepsays.com/en/2016/12/19/hugo-018/) everything become a page

We should iterate through `.Site.RegularPages` instead of `.Site.Pages`

fixes #203