### PR TITLE
Fixed typo in 'highligth.js' by replacing with 'highlight.js' globally.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ Please upgrade you're `config.toml` (you can checkout `exampleSite/config.toml` 
 
 ```toml
 [params]
-  syntaxHighlighter = "highligth.js"
+  syntaxHighlighter = "highlight.js"
 ```
 
 ## [0.4.1-BETA](https://github.com/kakawait/hugo-tranquilpeak-theme/milestone/16) - 11 sep 2017
@@ -39,7 +39,7 @@ Please upgrade you're `config.toml` (you can checkout `exampleSite/config.toml` 
   - _OLDER POSTS_ Button Overlaps Sidebar
   - Print media queries
 - Load external resources using SRI ([#159](https://github.com/kakawait/hugo-tranquilpeak-theme/issues/159))
-- revamp HLjs usage to fix highligthing bugs ([#154](https://github.com/kakawait/hugo-tranquilpeak-theme/issues/154), [#160](https://github.com/kakawait/hugo-tranquilpeak-theme/pull/160))
+- revamp HLjs usage to fix highlighting bugs ([#154](https://github.com/kakawait/hugo-tranquilpeak-theme/issues/154), [#160](https://github.com/kakawait/hugo-tranquilpeak-theme/pull/160))
 - Improve `customJS` and `customCSS`
   - Now support both abs and rel url ([#155](https://github.com/kakawait/hugo-tranquilpeak-theme/issues/155))
   - Add more customization than just url ([#163](https://github.com/kakawait/hugo-tranquilpeak-theme/pull/163))

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -107,9 +107,9 @@ canonifyurls = true
   # Global keywords configuration. Following keywords will be add to every pages
   # keywords = ["development", "next-gen"]
 
-  # Syntax highlighter, possible choice between: "highligth.js" (recommanded) and "prism.js" (experimental)
-  # You can comment it to disable syntax highligthing
-  syntaxHighlighter = "highligth.js"
+  # Syntax highlighter, possible choice between: "highlight.js" (recommanded) and "prism.js" (experimental)
+  # You can comment it to disable syntax highlighting
+  syntaxHighlighter = "highlight.js"
 
   # Hide sidebar on all article page to let article take full width to improve reading, and enjoy wide images and cover images. (true: enable, false: disable)
   clearReading = true

--- a/layouts/partials/script.html
+++ b/layouts/partials/script.html
@@ -1,6 +1,6 @@
 <!--EXTERNAL SCRIPTS-->
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.2.4/jquery.min.js" integrity="sha256-BbhdlvQf/xTY9gja0Dq3HiwQF8LaCRTXxZKRutelT44=" crossorigin="anonymous"></script>
-{{ if eq .Site.Params.syntaxHighlighter "highligth.js" }}
+{{ if eq .Site.Params.syntaxHighlighter "highlight.js" }}
   <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/highlight.min.js" integrity="sha256-/BfiIkHlHoVihZdc6TFuj7MmJ0TWcWsMXkeDFwhi0zw=" crossorigin="anonymous"></script>
 {{ else if eq .Site.Params.syntaxHighlighter "prism.js" }}
   <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.8.3/prism.min.js" integrity="sha256-haEv2ilTk2sXcJaGbkTtErRCHy/qGt3g+bGbgPf5OTY=" crossorigin="anonymous"></script>
@@ -17,7 +17,7 @@
     <script src="{{ . | absURL }}"></script>
   {{ end }}
 {{ end }}
-{{ if eq .Site.Params.syntaxHighlighter "highligth.js" }}
+{{ if eq .Site.Params.syntaxHighlighter "highlight.js" }}
 <script>
 $(document).ready(function() {
   hljs.configure({ classPrefix: '', useBR: false });


### PR DESCRIPTION
Thanks for you work on this template! Just a quick fix - I noticed this typo causing the highlighting to break if one specifies 'highlight.js' in config.toml.