### PR TITLE
Add custom summary / excerpt feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,24 @@ A gorgeous responsive theme for Hugo blog framework.
 
 ![Tranquilpeak](https://raw.githubusercontent.com/kakawait/hugo-tranquilpeak-theme/master/showcase.png)
 
+## ZacBook's Fork
+
+To independently tweak and modify this theme, yet keep it somewhat independent from my main Hugo blog, I decided to fork this theme.
+
+To facilitate obtaining updates from [Tranquilpeak's repository](https://github.com/kakawait), I've added his repository as an upstream remote via
+
+```bash
+git remote add upstream git@github.com:kakawait/hugo-tranquilpeak-theme.git
+```
+
+then updates from the `master` branch can be obtained via
+
+```bash
+git pull upstream master
+```
+
+My `master` fork contains my production theme that is deployed to my website.  I'm reserving the `develop` branch for pull requests to Tranquilpeak's repository, and have therefore created a `develop-zacbook` branch that contains my modifications to the theme.
+
 ## Alpha/Beta versions
 
 **ATTENTION** during *alpha* or *beta* [versions](https://github.com/kakawait/hugo-tranquilpeak-theme/milestones) breaking changes are possible on config file.

--- a/README.md
+++ b/README.md
@@ -4,24 +4,6 @@ A gorgeous responsive theme for Hugo blog framework.
 
 ![Tranquilpeak](https://raw.githubusercontent.com/kakawait/hugo-tranquilpeak-theme/master/showcase.png)
 
-## ZacBook's Fork
-
-To independently tweak and modify this theme, yet keep it somewhat independent from my main Hugo blog, I decided to fork this theme.
-
-To facilitate obtaining updates from [Tranquilpeak's repository](https://github.com/kakawait), I've added his repository as an upstream remote via
-
-```bash
-git remote add upstream git@github.com:kakawait/hugo-tranquilpeak-theme.git
-```
-
-then updates from the `master` branch can be obtained via
-
-```bash
-git pull upstream master
-```
-
-My `master` fork contains my production theme that is deployed to my website.  I'm reserving the `develop` branch for pull requests to Tranquilpeak's repository, and have therefore created a `develop-zacbook` branch that contains my modifications to the theme.
-
 ## Alpha/Beta versions
 
 **ATTENTION** during *alpha* or *beta* [versions](https://github.com/kakawait/hugo-tranquilpeak-theme/milestones) breaking changes are possible on config file.

--- a/docs/user.md
+++ b/docs/user.md
@@ -530,7 +530,8 @@ Please note, there are many different versions of Markdown and some of them are 
 Tranquilpeak introduces new variables to give you a lot of possibilities.  
   
 Example :  
-``` markdown
+
+```markdown
 disqusIdentifier: fdsF34ff34
 keywords:
 - javascript
@@ -555,6 +556,7 @@ showTags: true
 showPagination: true
 showSocial: true
 showDate: true
+summary: "This is a custom summary and does *not* appear in the post."
 ```
 
 |Variable|Description|
@@ -578,6 +580,7 @@ showDate: true
 |showSocial|`true`: show social button such as share on Twitter, Facebook...|
 |showMeta|`true`: Show post meta (date, categories).|
 |showActions|`true`: Show post actions (navigation, share links).|
+|summary|Custom excerpt text to show on the homepage.|
 
 Example: 
 A post on index page will look like this with :`thumbnailImagePosition` set to `bottom`:  
@@ -594,6 +597,7 @@ The same with : `thumbnailImagePosition` set to `left`:
 Use: 
 
 - `<!--more-->` to define post excerpt and keep the post excerpt in the post content
+- For a custom exerpt *not* in the post content, use the `summary` front-matter variable. Markdown syntax is supported.
 
 ### Display table of contents
 

--- a/layouts/_default/summary.html
+++ b/layouts/_default/summary.html
@@ -40,7 +40,11 @@
       {{ partial "post/meta" . }}
     </div>
     <div class="postShorten-excerpt" itemprop="articleBody">
-      {{ .Summary }}
+      {{ if .Params.Summary }}
+        {{ .Params.Summary | markdownify }}
+      {{ else }}
+        {{ .Summary }}
+      {{ end }}
       <p>
         <a href="{{ .Permalink }}" class="postShorten-excerpt_link link">{{ i18n "post.read_more" }}</a>
         {{ with .Params.readingtime }}


### PR DESCRIPTION
This allows additional flexibility in creating summaries of posts on the homepage via the front-matter variable `summary`. I implemented this because, currently, Blogdown's processing of Rmarkdown files results in `<!--more-->` being left as an HTML comment in the output.