### PR TITLE
Fix: js is broken on the page.

### DIFF
--- a/layouts/partials/post/actions.html
+++ b/layouts/partials/post/actions.html
@@ -1,5 +1,5 @@
-{{ if not (eq .Params.showActions false) }}
-  <div class="post-actions-wrap">
+<div class="post-actions-wrap">
+  {{ if not (eq .Params.showActions false) }}
       <nav {{ if eq .Params.showPagination false }}style="visibility: hidden"{{ end }}>
         <ul class="post-actions post-action-nav">
           {{ if .Site.Params.swapPaginator }}
@@ -79,5 +79,5 @@
         </a>
       </li>
     </ul>
-  </div>
-{{ end }}
+  {{ end }}
+</div>


### PR DESCRIPTION
js is broken on the page (https://github.com/kakawait/hugo-tranquilpeak-theme/blob/master/docs/user.md#writing-pages)

When I create the page command for default.
the front matter would be with this setting.

```
comments: false
showMeta: false
showActions: false
```

then https://github.com/kakawait/hugo-tranquilpeak-theme/blob/master/layouts/partials/post/actions.html#L2 this line is not render.

finally, https://github.com/kakawait/hugo-tranquilpeak-theme/blob/master/src/js/post-bottom-bar.js#L49 this line is broken.

because `<div class="post-actions-wrap">` this element cannot find by setting and the #top() method is not work.