### PR TITLE
move swapPaginator configuration

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -168,6 +168,10 @@ canonifyurls = true
   #     icon: search
   #     class: st-search-show-outputs
 
+  # Display `Next` on left side of the pagination, and `Prev` on right side one.
+  # If you set this value to `true`, these positions swap.
+  # swapPaginator = true
+
   # Custom CSS. Put here your custom CSS files. They are loaded after the theme CSS;
   # they have to be referred from static root. Example
   # [[params.customCSS]]
@@ -177,10 +181,6 @@ canonifyurls = true
   # they have to be referred from static root. Example
   # [[params.customJS]]
   #   src = "js/myscript.js"
-
-  # Display `Next` on left side of the pagination, and `Prev` on right side one.
-  # If you set this value to `true`, these positions swap.
-  # swapPaginator = true
 
   # Sharing options
   # Comment and uncomment to enable or disable sharing options


### PR DESCRIPTION
If used as it is, it will supply unexpected attributes to script tag. Therefore, moved the position.