### PR TITLE
Allow customJS for posts via metadata

### DIFF
--- a/layouts/partials/script.html
+++ b/layouts/partials/script.html
@@ -17,6 +17,13 @@
     <script src="{{ . | absURL }}"></script>
   {{ end }}
 {{ end }}
+{{ range .Params.customJS }}
+  {{ if isset . "src" }}
+    <script{{ range $key, $value := . }} {{ if eq $key "src" }}{{ (printf "%s=\"%s\"" $key ($value | absURL)) | safeHTMLAttr }}{{ else }}{{ (printf "%s=\"%s\"" $key (string $value)) | safeHTMLAttr }}{{ end }}{{ end }}></script>
+  {{ else }}
+    <script src="{{ . | absURL }}"></script>
+  {{ end }}
+{{ end }}
 {{ if eq .Site.Params.syntaxHighlighter "highlight.js" }}
 <script>
 $(document).ready(function() {


### PR DESCRIPTION
This change allows adding custom Javascript to posts in a way analogous to the global site.

To add a Javascript file to a post one only has to add a customJS option to the metadata like so

    ---
    title: "Code Test"
    date: 2018-03-28T12:32:57+02:00
    draft: false
    customJS:
         src: "js/myscript.js"
    ---
    ... rest of post ...

I'm not really happy with the code duplication but when I delete the `{{ range .Size.Params.customJS }}` site wide `customJS` breaks. So I'm not sure if there's a better way.