### PR TITLE
Adding description to header

### DIFF
--- a/layouts/_default/summary.html
+++ b/layouts/_default/summary.html
@@ -40,7 +40,11 @@
       {{ partial "post/meta" . }}
     </div>
     <div class="postShorten-excerpt" itemprop="articleBody">
-      {{ .Summary }}
+      {{if .Description }}
+        {{ .Description }}
+      {{ else }}
+        {{ .Summary }}
+      {{ end }}
       <p>
         <a href="{{ .Permalink }}" class="postShorten-excerpt_link link">{{ i18n "post.read_more" }}</a>
         {{ with .Params.readingtime }}


### PR DESCRIPTION
Hi,
I'm using your theme in my website, but when I added Rmarkdown on it, I couldn't change the summary text before the "read more". 

I am propose this commit because we can put the text as we want.

![description in header](https://user-images.githubusercontent.com/21323641/39448633-e19ecb8c-4c9b-11e8-8459-6f0c517d3325.png)

Thanks for your work, the theme is beautiful :)