### PR TITLE
Fix script attr defer/async

### DIFF
--- a/layouts/partials/script.html
+++ b/layouts/partials/script.html
@@ -12,7 +12,7 @@
 <!--SCRIPTS END-->
 {{ range .Site.Params.customJS }}
   {{ if isset . "src" }}
-    <script{{ range $key, $value := . }} {{ if eq $key "src" }}{{ (printf "%s=\"%s\"" $key ($value | absURL)) | safeHTMLAttr }}{{ else }}{{ (printf "%s=\"%s\"" $key (string $value)) | safeHTMLAttr }}{{ end }}{{ end }}></script>
+    <script{{ range $key, $value := . }} {{ if eq $key "src" }}{{ (printf "%s=\"%s\"" $key ($value | absURL)) | safeHTMLAttr }}{{ else if and (in "async defer" $key) }}{{ if $value }}{{ (printf "%s" $key) | safeHTMLAttr }}{{ end }}{{ else }}{{ (printf "%s=\"%s\"" $key (string $value)) | safeHTMLAttr }}{{ end }}{{ end }}></script>
   {{ else }}
     <script src="{{ . | absURL }}"></script>
   {{ end }}


### PR DESCRIPTION
On chrome you must not add `async=false` is not working properly to disable `async` instead you must no add attr

fixes #186