### PR TITLE
Make list template work for any content type

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -9,7 +9,8 @@
                {{ if eq .Params.covermeta "out" }}hasCoverMetaOut{{ else }}hasCoverMetaIn{{ end }}
                {{ with .Params.coverCaption }}hasCoverCaption{{ end }}">
         <section class="postShorten-group main-content-wrap">
-          {{ $paginator := .Paginate (where .Data.Pages "Type" "post") }}
+          {{/* Iterate only over pages of the same type as this section. */}}
+          {{ $paginator := .Paginate (where .Data.Pages "Type" .Type) }}
           {{ range $paginator.Pages }}
             {{ .Render "summary" }}
           {{ end }}


### PR DESCRIPTION
This change makes it easy to have a list for a section any type of content, not just `post` content. 
I've found this to be helpful for a site with multiple sections where I want to list content -- e.g. a "tutorials" and a "blog" section.

This change does not modify `index.html`, which will still list only content of type `post`.
