### PR TITLE
Fix warn 0.55 about RSSLink

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -29,8 +29,8 @@
     <title>{{ with .Title }}{{ . }}{{ else }}{{ .Site.Title }}{{ end }}</title>
 
     <link rel="icon" href="{{ with .Site.Params.favicon }}{{ . }}{{ else }}/favicon.png{{ end }}">
-    {{ with .RSSLink }}
-      <link rel="alternate" type="application/rss+xml" title="RSS" href="{{ . }}">
+    {{ with .OutputFormats.Get "RSS" }}
+    <link rel="alternate" type="application/rss+xml" title="RSS" href="{{ .RelPermalink }}">
     {{ end }}
 
     {{ with .Site.Author.googleplus }}


### PR DESCRIPTION
With the version 0.55 of Hugo, this warning appears:

```
WARN 2019/04/14 19:53:01 Page's .RSSLink is deprecated and will be removed in a future release. Use the Output Format's link, e.g. something like: 
    {{ with .OutputFormats.Get "RSS" }}{{ .RelPermalink }}{{ end }}.
```

This PR implements the given piece of advice included in the warning to remove it.