### PR TITLE
not showing in main cat if showed in sub cat

### DIFF
--- a/layouts/taxonomy/category.terms.html
+++ b/layouts/taxonomy/category.terms.html
@@ -82,9 +82,11 @@
                   </h4>
                   <ul class="archive-posts">
                     {{ range ($.Scratch.GetSortedMapValues $path) }}
+                      {{ if eq (len (after 1 .Params.categories)) 0 }}
                       <li class="archive-post">
                         <a class="archive-post-title" href="{{ .RelPermalink }}">{{ .Title }}</a><span class="archive-post-date"> - {{ partial "internal/date" . }}</span>
                       </li>
+                      {{ end }}
                     {{ end }}
                     {{ range seq ($.Scratch.Get "max-level") }}
                       {{ $index := . }}


### PR DESCRIPTION
This PR addresses the `duplicated display` in category page.

If configured to hierarchical categories, post will be present in both the main category and the sub-category. 

This `if` statement ensures a post will only show in main category list if it does not have any sub category declared.
