### PR TITLE
fix:warn when use 0.55.5

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -29,8 +29,8 @@
     <title>{{ with .Title }}{{ . }}{{ else }}{{ .Site.Title }}{{ end }}</title>
 
     <link rel="icon" href="{{ with .Site.Params.favicon }}{{ . }}{{ else }}/favicon.png{{ end }}">
-    {{ with .RSSLink }}
-      <link rel="alternate" type="application/rss+xml" title="RSS" href="{{ . }}">
+    {{ with .OutputFormats.Get "RSS" }}
+      <link rel="alternate" type="application/rss+xml" title="RSS" href="{{ .RelPermalink }}">
     {{ end }}
 
     {{ with .Site.Author.googleplus }}

--- a/layouts/partials/meta.html
+++ b/layouts/partials/meta.html
@@ -1,7 +1,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
-<meta name="generator" content="Hugo {{ .Hugo.Version }} with theme Tranquilpeak 0.4.3-SNAPSHOT">
+<meta name="generator" content="Hugo {{ hugo.Version }} with theme Tranquilpeak 0.4.3-SNAPSHOT">
 <meta name="author" content="{{ .Site.Author.name }}">
 <meta name="keywords" content="{{ with .Keywords }}{{ delimit . ", " }}{{ end }}{{ if .Site.Params.keywords }}, {{ delimit .Site.Params.keywords ", " }}{{ end }}">
 <meta name="description" content="{{ if .Description }}{{ .Description }}{{ else if .IsPage }}{{ .Summary }}{{ else }}{{ .Site.Params.description }}{{ end }}">

--- a/layouts/taxonomy/category.terms.html
+++ b/layouts/taxonomy/category.terms.html
@@ -23,7 +23,7 @@
           {{ $.Scratch.Set $name $node }}
           {{ $.Scratch.SetInMap $level $path $node }}
         {{ end }}
-        {{ $.Scratch.SetInMap (printf "%s" (delimit (first (add $index 1) $categories) "/")) $page.UniqueID $page }}
+        {{ $.Scratch.SetInMap (printf "%s" (delimit (first (add $index 1) $categories) "/")) $page.File.UniqueID $page }}
         {{ $.Scratch.Set "parent" $path }}
       {{ end }}
       {{ $.Scratch.Set "parent" nil }}


### PR DESCRIPTION
hugo version

```
$ hugo version
Hugo Static Site Generator v0.55.5/extended windows/amd64 BuildDate: unknown
```
warn:

```
$ hugo
Building sites … WARN 2019/05/17 19:58:25 Page's .Hugo is deprecated and will be removed in a future release. Use the global hugo function.
WARN 2019/05/17 19:58:25 Page's .RSSLink is deprecated and will be removed in a future release. Use the Output Format's link, e.g. something like:
    {{ with .OutputFormats.Get "RSS" }}{{ .RelPermalink }}{{ end }}.
WARN 2019/05/17 19:58:25 Page's .UniqueID is deprecated and will be removed in a future release. Use .File.UniqueID.
```

Changes to be committed:

* modified:   layouts/partials/head.html
* modified:   layouts/partials/meta.html
* modified:   layouts/taxonomy/category.terms.html