### PR TITLE
Cover img abs url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,18 @@ All notable changes to this project will be documented in this file.
 
 Do not support anymore Hugo version <= 0.30!
 
-`coverImage` from `config.toml` now more consistent by do not fix default static folder to `images` (see [#327](https://github.com/kakawait/hugo-tranquilpeak-theme/issues/327) for more details)
+`coverImage` from `config.toml` now more consistent by do not fix default static folder to `images` (see [#327](https://github.com/kakawait/hugo-tranquilpeak-theme/issues/327) for more details).
+`coverImage` from `param` will now always based on base path and not relative to current url, thus
+
+```yml
+coverImage: img/a.jpg
+```
+
+will the be the same as
+
+```yml
+coverImage: /img/a.jpg
+```
 
 ## [0.4.4-BETA](https://github.com/kakawait/hugo-tranquilpeak-theme/milestone/19) - 09 sep 2018
 

--- a/layouts/partials/post/header-cover.html
+++ b/layouts/partials/post/header-cover.html
@@ -2,7 +2,7 @@
   <div class="post-header-cover
               {{ if .Params.metaalignment }}text-{{ .Params.metaalignment }}{{ else }}text-left{{ end }}
               {{ with .Params.coversize }}post-header-cover--{{ . }}{{ end }}"
-       style="background-image:url('{{ .Params.coverimage }}')"
+       style="background-image:url('/{{ strings.TrimPrefix "/" .Params.coverimage }}')"
        data-behavior="{{ $.Scratch.Get "sidebarBehavior" }}">
     {{ if or (eq .Params.covermeta "in") (not .Params.covermeta) }}
       {{ partial "post/header.html" . }}


### PR DESCRIPTION
When using `param` `coverImage` will always fetch from base path and not relative to current page so

```
coverImage: img/a.jpg
coverImage: /img/a.jpg
```

will be the same