### PR TITLE
Class on sidebar menu does not work

### DIFF
--- a/docs/user.md
+++ b/docs/user.md
@@ -281,7 +281,6 @@ You can add groups of links and links much as you want.
 | name       | title to be display                   | string        |
 | pre        | icon to be display a left of the name | template.HTML |
 | url        | menu entry url                        | string        |
-| class      | CSS Class added to the `a` link tag   | string        |
 
 `identifier` can be use for translation see [Menu translation](#menu-translation).
 


### PR DESCRIPTION
Supplying a class for a link appears to be a feature in the [hexo version](https://github.com/LouisBarranqueiro/hexo-theme-tranquilpeak/blob/master/layout/_partial/sidebar.ejs#L33) of the theme, but there is no equivalent implementation [in this repo](https://github.com/kakawait/hugo-tranquilpeak-theme/blob/master/layouts/partials/menu.html#L6). I tried to figure out how to access the variable defined in Hugo's config.html from the partial, but I was not able to succeed. Is this a limitation by Hugo? If not if I can be pointed in the right direction I can make another try.

If this is not possible, may I instead suggest adding `.Menu` as a class on the anchor? That way at least an entire menu can be targeted via css.