### PR TITLE
Add Stackbit Integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,3 +154,8 @@ That mean I would keep a strong dependency with original *Hexo* theme. Thus if y
 
 hugo-tranquilpeak-theme is released under the terms of the [GNU General Public License v3.0](https://github.com/kakawait/hugo-tranquilpeak-theme/blob/master/LICENSE).
 
+# Stackbit Deploy
+
+This theme is ready to import into Stackbit. This theme can be deployed to Netlify and you can connect any headless CMS including Forestry, NetlifyCMS, DatoCMS or Contentful. 
+
+[![Create with Stackbit](https://assets.stackbit.com/badge/create-with-stackbit.svg)](https://app.stackbit.com/create?theme=https://github.com/kakawait/hugo-tranquilpeak-theme)

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,4 @@
+[build.environment]
+  HUGO_VERSION = "0.55.6"
+  HUGO_THEME = "repo"
+  HUGO_BASEURL = "/"

--- a/stackbit.yaml
+++ b/stackbit.yaml
@@ -25,7 +25,7 @@ models:
         label: Language Code "en"
       - type: string
         name: defaultContentLanguage
-        label: Language Code "en"
+        label: Default Content Language "en"
       - type: string
         name: theme
         label: Theme Name 

--- a/stackbit.yaml
+++ b/stackbit.yaml
@@ -171,10 +171,10 @@ models:
           - type: string
             name: description
             label: Description
-          - type: enum
+          - type: number
             name: sidebarBehavior
             label: Sidebar Behavior
-            options: [1, 2, 3, 4, 5, 6]
+            description: value should be in 1~6
           - type: image
             name: coverImage
             label: Cover Image

--- a/stackbit.yaml
+++ b/stackbit.yaml
@@ -1,0 +1,296 @@
+stackbitVersion: ~0.2.0
+ssgName: custom
+publishDir: exampleSite/public
+buildCommand: cd exampleSite && hugo --gc --baseURL "/" --themesDir ../.. && cd ..
+uploadDir: img
+staticDir: exampleSite/static
+pagesDir: exampleSite/content
+dataDir: exampleSite
+models:
+  config:
+    type: data
+    label: Config
+    file: config.toml
+    fields:
+      - type: string
+        name: title
+        label: Title
+        required: true
+      - type: string
+        name: baseURL
+        label: Base baseURL
+        description: Hostname (and path)  to the root
+      - type: string
+        name: languageCode
+        label: Language Code "en"
+      - type: string
+        name: defaultContentLanguage
+        label: Language Code "en"
+      - type: string
+        name: theme
+        label: Theme Name 
+      - type: string
+        name: themesDir
+        label: Themes Folder Path
+      - type: string
+        name: disqusShortname
+        label: Disqus Shortname
+      - type: string
+        name: googleAnalytics
+        label: Google Analytics ID
+      - type: number
+        name: paginate
+        label: Paginate
+      - type: boolean
+        name: canonifyurls
+        label: Canonify URLs
+      - type: object
+        name: permalinks
+        label: Permalinks
+        fields:
+          - type: string
+            name: post
+            label: Post Permalink
+      - type: object
+        name: taxonomies
+        label: Taxonomies
+        fields:
+          - type: string
+            name: tag
+            label: Tag
+          - type: string
+            name: category
+            label: Category
+          - type: string
+            name: archive
+            label: Archive
+      - type: object
+        name: author
+        label: Author
+        fields:
+          - type: string
+            name: name
+            label: Name
+          - type: string
+            name: bio
+            label: Bio
+          - type: string
+            name: job
+            label: Job
+          - type: string
+            name: location
+            label: Location
+          - type: string
+            name: gravatarEmail
+            label: Gravatar Email
+          - type: string
+            name: picture
+            label: Profile Picture
+      - type: object
+        name: menu
+        label: Menu
+        fields:
+          - type: list
+            name: main
+            label: Main menu
+            items:
+              type: object
+              fields:
+                - type: number
+                  name: weight
+                  label: Menu Order Weight
+                - type: string
+                  name: identifier
+                  label: Identifier
+                - type: string
+                  name: name
+                  label: Menu Name
+                - type: string
+                  name: pre
+                  label: Previous Icon
+                - type: string
+                  name: url
+                  label: Menu Link
+          - type: list
+            name: links
+            label: Links
+            items:
+              type: object
+              fields:
+                - type: number
+                  name: weight
+                  label: Order Weight
+                - type: string
+                  name: identifier
+                  label: Identifier
+                - type: string
+                  name: name
+                  label: Menu Name
+                - type: string
+                  name: pre
+                  label: Pre
+                - type: string
+                  name: url
+                  label: Icon Link
+          - type: list
+            name: misc
+            label: Misc
+            items:
+              type: object
+              fields:
+                - type: number
+                  name: weight
+                  label: Order Weight
+                - type: string
+                  name: identifier
+                  label: Identifier
+                - type: string
+                  name: name
+                  label: Menu Name
+                - type: string
+                  name: pre
+                  label: Pre
+                - type: string
+                  name: url
+                  label: URL
+      - type: object
+        name: params
+        label: Site Parameters
+        fields:
+          - type: string
+            name: dateFormat
+            label: Date Format
+            default: "January 2, 2006"
+          - type: enum
+            name: syntaxHighlighter
+            label: Syntax Highlighter JS
+            options: ["highlight.js", "prism.js"]
+          - type: boolean
+            name: clearReading
+            label: Clear Reading
+          - type: boolean
+            name: hierarchicalCategories
+            label: Hierarchical Categories
+          - type: string
+            name: description
+            label: Description
+          - type: enum
+            name: sidebarBehavior
+            label: Sidebar Behavior
+            options: [1, 2, 3, 4, 5, 6]
+          - type: image
+            name: coverImage
+            label: Cover Image
+          - type: boolean
+            name: imageGallery
+            label: Image Gallery
+          - type: boolean
+            name: thumbnailImage
+            label: Thumbnail Image
+          - type: enum
+            name: thumbnailImagePosition
+            label: Thumbnail Image Position
+            options: ["right", "left", "bottom"]
+          - type: boolean
+            name: autoThumbnailImage
+            label: Auto Thumbnail Image
+          - type: list
+            name: sharingOptions
+            label: Sharing Options
+            items:
+              type: object
+              fields:
+                - type: string
+                  name: name
+                  label: Name
+                - type: string
+                  name: icon
+                  label: Icon
+                - type: string
+                  name: url
+                  label: URL
+          - type: object
+            name: header
+            label: Header
+            fields:
+              - type: object
+                name: rightLink
+                label: Right Link
+                fields:
+                  - type: string
+                    name: class
+                    label: Class
+                  - type: string
+                    name: icon
+                    label: Icon
+                  - type: string
+                    name: url
+                    label: URL
+  post:
+    type: page
+    label: Blog Post
+    folder: post
+    fields: 
+      - type: string
+        name: title
+        label: Title
+      - type: string
+        name: slug
+        label: Slug
+      - type: date
+        name: date
+        label: Publish Date
+      - type: boolean
+        name: autoThumbnailImage
+        label: Auto Thumbnail Image
+      - type: enum
+        name: thumbnailImagePosition
+        label: Thumbnail Image Position
+        options: ["right", "left", "bottom"]
+      - type: string
+        name: thumbnailImage
+        label: Thumbnail Image
+      - type: string
+        name: coverImage
+        label: Cover Image
+      - type: string
+        name: coverMeta
+        label: Cover Meta
+      - type: enum
+        name: metaAlignment
+        label: Meta Alignment
+        options: ["right", "left", "center"]
+      - type: list
+        name: gallery
+        label: Image Gallery
+        items:
+          type: string
+      - type: list
+        name: categories
+        label: Post Categories
+        items: 
+          type: string
+      - type: list
+        name: tags
+        label: Post Tags
+        items: 
+          type: string
+      - type: list
+        name: keywords
+        label: Search keywords
+        items: 
+          type: string
+      - type: boolean
+        name: showPagination
+        label: Show Pagination
+      - type: boolean
+        name: showSocial
+        label: Show Social
+      - type: boolean
+        name: showTags
+        label: Show Tags
+
+
+
+
+

--- a/stackbit.yaml
+++ b/stackbit.yaml
@@ -2,8 +2,8 @@ stackbitVersion: ~0.2.0
 ssgName: custom
 publishDir: exampleSite/public
 buildCommand: cd exampleSite && hugo --gc --baseURL "/" --themesDir ../.. && cd ..
-uploadDir: img
-staticDir: exampleSite/static
+uploadDir: images
+staticDir: static
 pagesDir: exampleSite/content
 dataDir: exampleSite
 models:

--- a/stackbit.yaml
+++ b/stackbit.yaml
@@ -30,9 +30,6 @@ models:
         name: theme
         label: Theme Name 
       - type: string
-        name: themesDir
-        label: Themes Folder Path
-      - type: string
         name: disqusShortname
         label: Disqus Shortname
       - type: string
@@ -190,7 +187,7 @@ models:
           - type: enum
             name: thumbnailImagePosition
             label: Thumbnail Image Position
-            options: ["right", "left", "bottom"]
+            options: ["top", "right", "bottom", "left"]
           - type: boolean
             name: autoThumbnailImage
             label: Auto Thumbnail Image
@@ -246,7 +243,7 @@ models:
       - type: enum
         name: thumbnailImagePosition
         label: Thumbnail Image Position
-        options: ["right", "left", "bottom"]
+        options: ["top", "right", "bottom", "left"]
       - type: string
         name: thumbnailImage
         label: Thumbnail Image


### PR DESCRIPTION
This pull request add's Stackbit to this Hugo theme. It add's the stackbit.yaml file which makes this theme work with several headless CMS automatically (including Forestry, NetlifyCMS, DatoCMS & Contentful) and it deploys the site to Netlify in 1 click.

You can try it out: https://app.stackbit.com/create?theme=https://github.com/stackbithq/hugo-tranquilpeak-theme (note the "create with stackbit" button in the readme will import the theme from your repo so until the PR is merged it wont work)

I think this is really valuable and is a very low impact addition on your existing theme structure. Pretty much just the stackbit.yaml file. If you have questions or feedback I'm happy to discuss.

Risto