### PR TITLE
Correct behaviour for Twitter cards

### DIFF
--- a/layouts/partials/meta.html
+++ b/layouts/partials/meta.html
@@ -58,25 +58,25 @@
   {{ end }}
 {{ end }}
 
-{{ with .Params.thumbnailImage }}
-  <meta property="og:image" content="{{ . | absURL }}">
-  <meta property="twitter:image" content="{{ . | absURL }}">
-{{ end }}
-{{ with .Params.coverImage }}
-  <meta property="og:image" content="{{ . | absURL }}">
-  <meta property="twitter:image" content="{{ . | absURL }}">
-{{ end }}
-{{ with .Params.gallery }}
-  {{ range . }}
-    <meta property="og:image" content="{{ range first 1 (split . " ") }}{{ . | absURL }}{{ end }}">
-    <meta property="twitter:image" content="{{ range first 1 (split . " ") }}{{ . | absURL }}{{ end }}">
-  {{ end }}
-{{ end }}
-
 {{ if .Scratch.Get "gravatarEmail" }}
   <meta property="og:image" content="https://www.gravatar.com/avatar/{{ (md5 (.Scratch.Get "gravatarEmail")) | urlize }}?s=640">
   <meta property="twitter:image" content="https://www.gravatar.com/avatar/{{ (md5 (.Scratch.Get "gravatarEmail")) | urlize }}?s=640">
 {{ else if .Site.Author.picture }}
   <meta property="og:image" content="{{ .Site.Author.picture | absURL }}">
   <meta property="twitter:image" content="{{ .Site.Author.picture | absURL }}">
+{{ end }}
+
+{{ with .Params.gallery }}
+  {{ range . }}
+    <meta property="og:image" content="{{ range first 1 (split . " ") }}{{ . | absURL }}{{ end }}">
+    <meta property="twitter:image" content="{{ range first 1 (split . " ") }}{{ . | absURL }}{{ end }}">
+  {{ end }}
+{{ end }}
+{{ with .Params.coverImage }}
+  <meta property="og:image" content="{{ . | absURL }}">
+  <meta property="twitter:image" content="{{ . | absURL }}">
+{{ end }}
+{{ with .Params.thumbnailImage }}
+  <meta property="og:image" content="{{ . | absURL }}">
+  <meta property="twitter:image" content="{{ . | absURL }}">
 {{ end }}


### PR DESCRIPTION
Social cards don't use images as explained in [user documentation](https://github.com/kakawait/hugo-tranquilpeak-theme/blob/master/docs/user.md#social-cards).
You may test it with [this tool](https://cards-dev.twitter.com/validator) (requires Twitter developer account). For example:

- [Element showcase](https://tranquilpeak.kakawait.com/2015/05/elements-showcase/) shows gravatar image
- [Element showcase](https://louisbarranqueiro.github.io/hexo-theme-tranquilpeak/2015/05/28/Elements-showcase/) (at original Hexo theme) shows thumbnail image

The order of `meta property="twitter:image"` was correct, just reversed.