### PR TITLE
Fixes back to post top anchor

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -8,7 +8,7 @@
         class="{{ with .Params.coverimage }}hasCover{{ end }}
                {{ if eq .Params.covermeta "out" }}hasCoverMetaOut{{ else }}hasCoverMetaIn{{ end }}
                {{ with .Params.coverCaption }}hasCoverCaption{{ end }}">
-        <article class="post">
+        <article class="post" id="top">
           {{ with .Params.covercaption }}
             <span class="post-header-cover-caption caption">{{ . | markdownify }}</span>
           {{ end }}

--- a/layouts/partials/post/actions.html
+++ b/layouts/partials/post/actions.html
@@ -78,10 +78,11 @@
       <li class="post-action">
         {{ if findRE "<!--\\s*[t|T][o|O][c|C]\\s*-->" .Content }}
           <a class="post-action-btn btn btn--default" href="#table-of-contents" aria-label="{{ i18n "post.toc" }}">
-        {{ else }}
-          <a class="post-action-btn btn btn--default" href="#" aria-label="{{ i18n "post.back_to_top" }}">
-        {{ end }}
           <i class="fa fa-list" aria-hidden="true"></i>
+        {{ else }}
+          <a class="post-action-btn btn btn--default" href="#top" aria-label="{{ i18n "post.back_to_top" }}">
+          <i class="fa fa-arrow-up" aria-hidden="true"></i>
+        {{ end }}
         </a>
       </li>
     </ul>


### PR DESCRIPTION
* Modify fontawesome icon for back to top: use _arrow_ instead of _list_ that is only used when a _TOC_ is present
* I had to use a _named anchor_ instead of only the `<a href="#">` that was supposed to work :man_shrugging: 

Thanks for your theme :+1: 