### PR TITLE
Add MermaidJS plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ How can I migrate my current version? Please read [CHANGELOG.md](https://github.
 - Image gallery
 - Tags for images (FancyBox), wide images, tabbed code blocks, highlighted text, alerts
 - Table of contents
+- Add diagrams and visualizations using text (https://mermaid-js.github.io/mermaid/#/)
 
 **Integrated services:**
 

--- a/docs/user.md
+++ b/docs/user.md
@@ -55,6 +55,7 @@ If you want to report a bug or ask a question, [create an issue](https://github.
     - [Image](#image)
     - [Tabbed code block](#tabbed-code-block)
     - [Wide image](#wide-image)
+    - [Mermaid diagram](#mermaid-diagram)
 - [Writing pages](#writing-pages)
 - [Running](#running)
 
@@ -89,6 +90,7 @@ If you want to report a bug or ask a question, [create an issue](https://github.
 - Image gallery
 - Tags for images (FancyBox), wide images, tabbed code blocks, highlighted text, alerts
 - Table of contents
+- Add diagrams and visualizations using text (https://mermaid-js.github.io/mermaid/#/)
 
 **Integrated services:**
 
@@ -603,6 +605,7 @@ keywords:
 - javascript
 - hexo
 clearReading: true
+mermaid: true
 thumbnailImage: image-1.png
 thumbnailImagePosition: bottom
 autoThumbnailImage: yes
@@ -630,6 +633,7 @@ summary: "This is a custom summary and does *not* appear in the post."
 |disqusIdentifier|Define a unique string which is used to look up a page's thread in the Disqus system.|
 |keywords|Define keywords for search engines. you can also define global keywords in Hugo configuration file.|
 |clearReading|Hide sidebar on all article page to let article take full width to improve reading, and enjoy wide images and cover images. Useless if `params.sidebarBehavior` is equal to `3` or `4`. (true: enable, false: disable). Default behavior : `params.clearReading` value in theme configuration file.|
+|mermaid|Enable mermaid pluging on this post|
 |autoThumbnailImage|Automatically select the cover image or the first photo from the gallery of a post if there is no thumbnail image as the thumbnail image. `autoThumbnailImage` overwrite the setting `autoThumbnailImage` in the theme configuration file|
 |thumbnailImage|Image displayed in index view.|
 |thumbnailImagePosition|Display thumbnail image at the right of title in index pages (`right`, `left` or `bottom`). `thumbnailImagePosition` overwrite the setting `thumbnailImagePosition` in the theme configuration file|
@@ -821,6 +825,38 @@ E.g:
 |src|Path to the original image.|
 |title (optional)|Title of image displayed in a caption under image. `Alt` HTML attribute will use this title. E.g : `"A beautiful sunrise"`.|
 
+#### Mermaid diagram
+
+Diagram and schema are useful to explain complex workflow or system : flowchart, sequence diagram, state diagram, Gantt, pie chart and many others. You can embed it with beautiful library MermaidJS (https://mermaid-js.github.io/mermaid/#/) !
+
+E.g
+```
+{{<mermaid>}}
+graph TD
+    A[Choosing an OS] --> B{Do you fear technology ?}
+    B -->|Yes| C{Is your daddy rich ?}
+    C -->|Yes| E(fa:fa-apple Mac OS);
+    C -->|No| F(fa:fa-chrome Chrome OS);
+    
+    B -->|No| D{Do you care about freedom/privacy ?}
+    D -->|Yes| G{Do you have a life ?}
+    D -->|No| H(fa:fa-windows Windows);
+    
+    G -->|Yes| I(fa:fa-ubuntu Ubuntu);
+    G -->|Yes| K(fa:fa-fedora Fedora);
+    G -->|No| L(fa:fa-linux Archlinux);
+    G -->|No| M(fa:fa-shield Backtrack);
+
+    style A fill:#0094FF,stroke:#333,stroke-width:4px,color:#fff
+    style E fill:#808080,stroke:#333,stroke-width:2px,color:#fff,stroke-dasharray: 5 5
+    style F fill:#808080,stroke:#333,stroke-width:2px,color:#fff,stroke-dasharray: 5 5
+    style H fill:#004A7F,stroke:#333,stroke-width:2px,color:#fff,stroke-dasharray: 5 5
+    style I fill:#FF6A00,stroke:#333,stroke-width:2px,color:#fff,stroke-dasharray: 5 5
+    style K fill:#FF6A00,stroke:#333,stroke-width:2px,color:#fff,stroke-dasharray: 5 5
+    style L fill:#7F0000,stroke:#333,stroke-width:2px,color:#fff,stroke-dasharray: 5 5
+    style M fill:#7F0000,stroke:#333,stroke-width:2px,color:#fff,stroke-dasharray: 5 5
+{{< /mermaid >}}
+```
 
 ## Writing pages ##
 

--- a/layouts/partials/script.html
+++ b/layouts/partials/script.html
@@ -3,11 +3,10 @@
 {{ if eq .Site.Params.syntaxHighlighter "highlight.js" }}
   <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.1.0/highlight.min.js" integrity="sha512-z+/WWfyD5tccCukM4VvONpEtLmbAm5LDu7eKiyMQJ9m7OfPEDL7gENyDRL3Yfe8XAuGsS2fS4xSMnl6d30kqGQ==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
 {{ else if eq .Site.Params.syntaxHighlighter "prism.js" }}
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.8.3/prism.min.js" integrity="sha256-haEv2ilTk2sXcJaGbkTtErRCHy/qGt3g+bGbgPf5OTY=" crossorigin="anonymous"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.24.1/prism.min.js" integrity="sha512-axJX7DJduStuBB8ePC8ryGzacZPr3rdLaIDZitiEgWWk2gsXxEFlm4UW0iNzj2h3wp5mOylgHAzBzM4nRSvTZA==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
 {{ end }}
-<script src="https://cdnjs.cloudflare.com/ajax/libs/fancybox/2.1.7/js/jquery.fancybox.min.js" integrity="sha256-GEAnjcTqVP+vBp3SSc8bEDQqvWAZMiHyUSIorrWwH50=" crossorigin="anonymous"></script>
 {{ if (.Params.mermaid) }}
-  <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/mermaid/dist/mermaid.min.js" crossorigin="anonymous"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/mermaid/8.12.1/mermaid.min.js" integrity="sha512-08D1plquyGkiMn9uWbY5ZgCrfpZo5hZ6Ab89VPOCZ8zGkPU428uaUDAAqYjCMrbz2ECFG/VR8v470aY9CiB1HA==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
   <script>
     mermaid.initialize({ startOnLoad: true });
   </script>

--- a/layouts/partials/script.html
+++ b/layouts/partials/script.html
@@ -3,7 +3,14 @@
 {{ if eq .Site.Params.syntaxHighlighter "highlight.js" }}
   <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.1.0/highlight.min.js" integrity="sha512-z+/WWfyD5tccCukM4VvONpEtLmbAm5LDu7eKiyMQJ9m7OfPEDL7gENyDRL3Yfe8XAuGsS2fS4xSMnl6d30kqGQ==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
 {{ else if eq .Site.Params.syntaxHighlighter "prism.js" }}
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.24.1/prism.min.js" integrity="sha512-axJX7DJduStuBB8ePC8ryGzacZPr3rdLaIDZitiEgWWk2gsXxEFlm4UW0iNzj2h3wp5mOylgHAzBzM4nRSvTZA==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.8.3/prism.min.js" integrity="sha256-haEv2ilTk2sXcJaGbkTtErRCHy/qGt3g+bGbgPf5OTY=" crossorigin="anonymous"></script>
+{{ end }}
+<script src="https://cdnjs.cloudflare.com/ajax/libs/fancybox/2.1.7/js/jquery.fancybox.min.js" integrity="sha256-GEAnjcTqVP+vBp3SSc8bEDQqvWAZMiHyUSIorrWwH50=" crossorigin="anonymous"></script>
+{{ if (.Params.mermaid) }}
+  <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/mermaid/dist/mermaid.min.js" crossorigin="anonymous"></script>
+  <script>
+    mermaid.initialize({ startOnLoad: true });
+  </script>
 {{ end }}
 <script src="https://cdnjs.cloudflare.com/ajax/libs/fancybox/3.5.7/jquery.fancybox.min.js" integrity="sha512-uURl+ZXMBrF4AwGaWmEetzrd+J5/8NRkWAvJx5sbPSSuOb0bZLqf+tOzniObO00BjHa/dD7gub9oCGMLPQHtQA==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
 <!--EXTERNAL SCRIPTS END-->

--- a/layouts/shortcodes/mermaid.html
+++ b/layouts/shortcodes/mermaid.html
@@ -1,0 +1,3 @@
+<div class="mermaid" align="{{ if .Get "align" }}{{ .Get "align" }}{{ else }}center{{ end }}">
+    {{ safeHTML .Inner }}
+</div>


### PR DESCRIPTION
This pull request add MermaidJS shortcode to this theme (you can see a example here : https://anceret-matthieu.fr/2020/09/mermaid/).
Mermaid allow to draw diagram and schema with text (Markdown syntax like).

If you have questions or feedback I'm happy to discuss.

Matthieu.