### PR TITLE
Fix script url for BaseUrl with path

### DIFF
--- a/layouts/partials/script.html
+++ b/layouts/partials/script.html
@@ -14,7 +14,7 @@
 <script src="https://cdnjs.cloudflare.com/ajax/libs/fancybox/3.5.7/jquery.fancybox.min.js" integrity="sha512-uURl+ZXMBrF4AwGaWmEetzrd+J5/8NRkWAvJx5sbPSSuOb0bZLqf+tOzniObO00BjHa/dD7gub9oCGMLPQHtQA==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
 <!--EXTERNAL SCRIPTS END-->
 <!--SCRIPTS-->
-<script src="{{ "/js/script-yqzy9wdlzix4lbbwdnzvwx3egsne77earqmn73v9uno8aupuph8wfguccut.min.js" | absURL }}"></script>
+<script src="{{ "js/script-yqzy9wdlzix4lbbwdnzvwx3egsne77earqmn73v9uno8aupuph8wfguccut.min.js" | absURL }}"></script>
 <!--SCRIPTS END-->
 {{ range .Site.Params.customJS }}
   {{ if isset . "src" }}


### PR DESCRIPTION
The URL generated for the javascript file is broken in the case that the baseURL has a path (e.g. https://www.example.com/my_blog)

The discussion at https://discourse.gohugo.io/t/absurl-function-strips-path-when-using-baseurl-flag/5925 suggests that when there is a '/' at the start of the input to absURL, the URL generated will be relative to the server/host (which I believe isn't what we want here).

This change works for me for URLs both with and without paths. 
