### PR TITLE
Do not insert leading comma when local keywords are empty

### DIFF
--- a/layouts/partials/meta.html
+++ b/layouts/partials/meta.html
@@ -3,7 +3,7 @@
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="generator" content="Hugo {{ hugo.Version }} with theme Tranquilpeak 0.6.0-SNAPSHOT">
 <meta name="author" content="{{ .Site.Author.name }}">
-<meta name="keywords" content="{{ with .Keywords }}{{ delimit . ", " }}{{ end }}{{ if .Site.Params.keywords }}, {{ delimit .Site.Params.keywords ", " }}{{ end }}">
+<meta name="keywords" content="{{ with .Keywords }}{{ delimit . ", " }}{{ end }}{{ if and .Keywords .Site.Params.keywords }}, {{ end }}{{ with .Site.Params.Keywords }}{{ delimit . ", "}}{{ end }}">
 <meta name="description" content="{{ if .Description }}{{ .Description }}{{ else if .IsPage }}{{ .Summary }}{{ else }}{{ .Site.Params.description }}{{ end }}">
 
 <!-- Meta Social -->


### PR DESCRIPTION
Currently, pages without local `.Keywords` but with `.Site.Params.keywords` end up with `<meta name="keywords" content=", keyword1, keyword2">`. With this fix, it's going to be `<meta name="keywords" content="keyword1, keyword2">`.