### PR TITLE
Add custom menu item param to set url function

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ How can I migrate my current version? Please read [CHANGELOG.md](https://github.
 
 - **Authors**: [Thibaud Leprêtre (kakawait)](https://github.com/kakawait) and [Louis Barranqueiro (LouisBarranqueiro)](https://github.com/LouisBarranqueiro)
 - **Version**: 0.6.0-SNAPSHOT (based on Hexo version 3.1.0)
-- **Compatibility**: Hugo v0.53
+- **Compatibility**: Hugo v0.79
 
 ## Features
 

--- a/layouts/partials/menu.html
+++ b/layouts/partials/menu.html
@@ -1,9 +1,9 @@
 {{ range .menu }}
   <li class="sidebar-button">
     {{ if and (or (in .URL "://") (in .URL "mailto:") (in .URL "tel:") (in .URL "callto:") (in .URL "skype:")) (not (and $.root.Site.BaseURL (in .URL (printf "%s" $.root.Site.BaseURL)))) }}
-      <a class="sidebar-button-link {{ if eq .Identifier "search" }}open-algolia-search{{ end }}" href="{{ .URL | safeURL }}" target="_blank" rel="noopener" title="{{ .Name }}">
+      <a class="sidebar-button-link {{ if eq .Identifier "search" }}open-algolia-search{{ end }}" href="{{ .URL | safeURL }}" title="{{ .Name }}" target="_blank" rel="noopener">
     {{ else }}
-      <a class="sidebar-button-link {{ if eq .Identifier "search" }}open-algolia-search{{ end }}" href="{{ .URL | relLangURL }}" title="{{ .Name }}">
+      <a class="sidebar-button-link {{ if eq .Identifier "search" }}open-algolia-search{{ end }}" href="{{ index (apply (slice .URL) (.Params.urlFunc | default "relLangURL") ".") 0 }}" title="{{ .Name }}">
     {{ end }}
       {{ .Pre }}
       {{ $name := (i18n (printf "global.%s" .Identifier)) }}

--- a/theme.toml
+++ b/theme.toml
@@ -5,7 +5,7 @@ description = "A gorgeous responsive theme for Hugo blog framework"
 homepage = "https://github.com/kakawait/hugo-tranquilpeak-theme"
 tags = ["blog", "minimal", "responsive", "personal", "customizable", "creative", "fontawesome", "highlight.js"]
 features = ["blog", "themes", "disqus", "minimal", "responsive", "font awesome", "highlight.js"]
-min_version = 0.53
+min_version = 0.79
 
 [author]
   name = "Thibaud Leprêtre"


### PR DESCRIPTION
By default, the code will behave the same and no changes in `config.yml` are required. When needed, there will be now a possibility to customize template function used to generate menu item URLs to allow to link to pages written in another language. Hugo >= 0.79.0 is required to use menu `.Params`. Example usage:
```yaml
languages:
  pl:
    menu:
      main:
      - name: Page
        url: /en/page/
        params:
          urlFunc: relURL
```